### PR TITLE
added automaticallyAdjustsScrollIndicatorInsets option to ios

### DIFF
--- a/ios/Classes/InAppWebView.swift
+++ b/ios/Classes/InAppWebView.swift
@@ -856,6 +856,10 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate, WKNavi
         if (options?.clearCache)! {
             clearCache()
         }
+        
+        if #available(iOS 13.0, *) {
+            scrollView.automaticallyAdjustsScrollIndicatorInsets = (options?.automaticallyAdjustsScrollIndicatorInsets)!
+        }
     }
     
     @available(iOS 10.0, *)
@@ -1239,7 +1243,7 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate, WKNavi
             
             if error != nil {
                 let userInfo = (error! as NSError).userInfo
-                self.onConsoleMessage(message: userInfo["WKJavaScriptExceptionMessage"] as! String, messageLevel: 3)
+                self.onConsoleMessage(message: userInfo["WKJavaScriptExceptionMessage"] as? String ?? "", messageLevel: 3)
             }
             
             if value == nil {

--- a/ios/Classes/InAppWebViewOptions.swift
+++ b/ios/Classes/InAppWebViewOptions.swift
@@ -49,6 +49,7 @@ public class InAppWebViewOptions: Options {
     var dataDetectorTypes: [String] = ["NONE"] // WKDataDetectorTypeNone
     var preferredContentMode = 0
     var sharedCookiesEnabled = false
+    var automaticallyAdjustsScrollIndicatorInsets = true
     
     override init(){
         super.init()

--- a/lib/src/webview_options.dart
+++ b/lib/src/webview_options.dart
@@ -606,6 +606,12 @@ class IosInAppWebViewOptions
   ///**NOTE**: available on iOS 11.0+.
   bool sharedCookiesEnabled;
 
+  ///Set `false` if scrollView of WKWebView should not automatically adjust scroll indicator insets.
+  ///The default value is `true`.
+  ///
+  ///**NOTE**: available on iOS 13.0+.
+  bool automaticallyAdjustsScrollIndicatorInsets;
+
   IosInAppWebViewOptions(
       {this.disallowOverScroll = false,
       this.enableViewportScale = false,
@@ -619,7 +625,8 @@ class IosInAppWebViewOptions
       this.isFraudulentWebsiteWarningEnabled = true,
       this.selectionGranularity = IosInAppWebViewSelectionGranularity.DYNAMIC,
       this.dataDetectorTypes = const [IosInAppWebViewDataDetectorTypes.NONE],
-      this.sharedCookiesEnabled = false});
+      this.sharedCookiesEnabled = false,
+      this.automaticallyAdjustsScrollIndicatorInsets = true});
 
   @override
   Map<String, dynamic> toMap() {
@@ -643,7 +650,9 @@ class IosInAppWebViewOptions
       "isFraudulentWebsiteWarningEnabled": isFraudulentWebsiteWarningEnabled,
       "selectionGranularity": selectionGranularity.toValue(),
       "dataDetectorTypes": dataDetectorTypesList,
-      "sharedCookiesEnabled": sharedCookiesEnabled
+      "sharedCookiesEnabled": sharedCookiesEnabled,
+      "automaticallyAdjustsScrollIndicatorInsets":
+          automaticallyAdjustsScrollIndicatorInsets
     };
   }
 


### PR DESCRIPTION
## Connection with issue(s)

Connected to #210 

## Testing and Review Notes

As mentioned in the issue, on notched iphones running ios 13+, scroll bar of the webview is displayed in the middle of the screen. This issue is also mentioned in flutter/flutter#41592. 
A fix was proposed in flutter/plugins#2343.  As seen in this fix I added automaticallyAdjustsScrollIndicatorInsets option to IosInAppWebViewOptions. This is not a breaking change since the default value is true; nothing changes if this option is not set to false.

Also I changed a forced unwrapping because I encountered a crash.