### PR TITLE
Fix crash on nil/invalid URL (iOS)

### DIFF
--- a/ios/Classes/FlutterWebViewController.swift
+++ b/ios/Classes/FlutterWebViewController.swift
@@ -98,14 +98,16 @@ public class FlutterWebViewController: FlutterMethodCallDelegate, FlutterPlatfor
         }
         
         if initialData != nil {
-            let data = (initialData!["data"] as? String)!
-            let mimeType = (initialData!["mimeType"] as? String)!
-            let encoding = (initialData!["encoding"] as? String)!
-            let baseUrl = (initialData!["baseUrl"] as? String)!
+            let data = (initialData!["data"])!
+            let mimeType = (initialData!["mimeType"])!
+            let encoding = (initialData!["encoding"])!
+            let baseUrl = (initialData!["baseUrl"])!
             webView!.loadData(data: data, mimeType: mimeType, encoding: encoding, baseUrl: baseUrl)
         }
         else {
-            webView!.loadUrl(url: URL(string: initialUrl)!, headers: initialHeaders)
+            if let url = URL(string: initialUrl) {
+                webView!.loadUrl(url: url, headers: initialHeaders)
+            }
         }
     }
     
@@ -347,7 +349,7 @@ public class FlutterWebViewController: FlutterMethodCallDelegate, FlutterPlatfor
             case "printCurrentPage":
                 if webView != nil {
                     webView!.printCurrentPage(printCompletionHandler: {(completed, error) in
-                        if !completed, let e = error {
+                        if !completed, let _ = error {
                             result(false)
                             return
                         }

--- a/lib/src/in_app_webview.dart
+++ b/lib/src/in_app_webview.dart
@@ -383,7 +383,7 @@ class _InAppWebViewState extends State<InAppWebView> {
         gestureRecognizers: widget.gestureRecognizers,
         layoutDirection: TextDirection.rtl,
         creationParams: <String, dynamic>{
-          'initialUrl': Uri.parse(widget.initialUrl),
+          'initialUrl': '${Uri.parse(widget.initialUrl)}',
           'initialFile': widget.initialFile,
           'initialData': widget.initialData?.toMap(),
           'initialHeaders': widget.initialHeaders,
@@ -416,7 +416,7 @@ class _InAppWebViewState extends State<InAppWebView> {
         onPlatformViewCreated: _onPlatformViewCreated,
         gestureRecognizers: widget.gestureRecognizers,
         creationParams: <String, dynamic>{
-          'initialUrl': Uri.parse(widget.initialUrl),
+          'initialUrl': '${Uri.parse(widget.initialUrl)}',
           'initialFile': widget.initialFile,
           'initialData': widget.initialData?.toMap(),
           'initialHeaders': widget.initialHeaders,

--- a/lib/src/in_app_webview.dart
+++ b/lib/src/in_app_webview.dart
@@ -383,7 +383,7 @@ class _InAppWebViewState extends State<InAppWebView> {
         gestureRecognizers: widget.gestureRecognizers,
         layoutDirection: TextDirection.rtl,
         creationParams: <String, dynamic>{
-          'initialUrl': widget.initialUrl,
+          'initialUrl': Uri.parse(widget.initialUrl),
           'initialFile': widget.initialFile,
           'initialData': widget.initialData?.toMap(),
           'initialHeaders': widget.initialHeaders,
@@ -416,7 +416,7 @@ class _InAppWebViewState extends State<InAppWebView> {
         onPlatformViewCreated: _onPlatformViewCreated,
         gestureRecognizers: widget.gestureRecognizers,
         creationParams: <String, dynamic>{
-          'initialUrl': widget.initialUrl,
+          'initialUrl': Uri.parse(widget.initialUrl),
           'initialFile': widget.initialFile,
           'initialData': widget.initialData?.toMap(),
           'initialHeaders': widget.initialHeaders,


### PR DESCRIPTION
## Connection with issue(s)

No unsolved issue, but might be similar to #74 and #174 .

## Testing and Review Notes

Pass a url include whitespace (e.g. 'https://www.google.com '), app will crash immediately.
By adding this, there're still many codes using `!` for force parsing, it require further modification.

## To Do

Nothing needs to be handled.
