### PR TITLE
Fix crash when `prompt` was called on Android Q.

### DIFF
--- a/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/InAppWebView/InputAwareWebView.java
+++ b/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/InAppWebView/InputAwareWebView.java
@@ -3,6 +3,7 @@ package com.pichillilorenzo.flutter_inappwebview.InAppWebView;
 import static android.content.Context.INPUT_METHOD_SERVICE;
 
 import android.content.Context;
+import android.os.Build;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.View;
@@ -190,7 +191,11 @@ public class InputAwareWebView extends WebView {
                         // onCreateInputConnection() on targetView on the same thread as
                         // targetView.getHandler(). It will also call subsequent InputConnection methods on this
                         // thread. This is the IME thread in cases where targetView is our proxyAdapterView.
-                        imm.isActive(containerView);
+
+                        // TODO (ALexVincent525): Currently only prompt has been tested, still needs more test cases.
+                        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+                            imm.isActive(containerView);
+                        }
                     }
                 });
     }


### PR DESCRIPTION
## Connection with issue(s)

Connected to #261 .

## Testing and Review Notes

1. Visit a web page included `window.prompt` (e.g. https://www.w3schools.com/jsref/tryit.asp?filename=tryjsref_prompt).
2. Call `window.prompt` then the app crashed.

## To Do

- [ ] test with more cases