### PR TITLE
Fix HTTPCookie.secure

### DIFF
--- a/ios/Classes/MyCookieManager.swift
+++ b/ios/Classes/MyCookieManager.swift
@@ -90,7 +90,9 @@ class MyCookieManager: NSObject, FlutterPlugin {
         if maxAge != nil {
             properties[.maximumAge] = String(maxAge!)
         }
-        properties[.secure] = (isSecure != nil && isSecure!) ? "TRUE" : "FALSE"
+        if isSecure != nil && isSecure! {
+            properties[.secure] = "TRUE"
+        }
         
         let cookie = HTTPCookie(properties: properties)!
         MyCookieManager.httpCookieStore!.setCookie(cookie, completionHandler: {() in


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #118 

## Testing and Review Notes

According to https://developer.apple.com/documentation/foundation/httpcookiepropertykey/1392985-secure, `.secure` key of `HTTPCookie` shouldn't be set when the cookie isn't secure. Otherwise, cookies are always 'secure' and won't work on http urls.
