### PR TITLE
Use PlatformViewLink widget for Android WebView

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@ Instead, on the `onLoadStop` WebView event, you can use `callHandler` directly:
 
 ##### `InAppWebView` Android-specific options
 
+* `useHybridComposition`: Set to `true` to use Flutter's new Hybrid Composition rendering method, which fixes all issues [here](https://github.com/flutter/flutter/issues/61133). The default value is `false`. Note that this option requires Flutter v1.20+ and should only be used on Android 10+ for release apps, as animations will drop frames on < Android 10.
 * `useShouldInterceptRequest`: Set to `true` to be able to listen at the `androidShouldInterceptRequest` event. The default value is `false`.
 * `useOnRenderProcessGone`: Set to `true` to be able to listen at the `androidOnRenderProcessGone` event. The default value is `false`.
 * `textZoom`: Sets the text zoom of the page in percent. The default value is `100`.

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
         <activity android:theme="@style/AppTheme" android:name="com.pichillilorenzo.flutter_inappwebview.InAppBrowser.InAppBrowserActivity" android:configChanges="orientation|screenSize"></activity>
         <activity android:theme="@style/ThemeTransparent" android:name="com.pichillilorenzo.flutter_inappwebview.ChromeCustomTabs.ChromeCustomTabsActivity" android:configChanges="orientation|screenSize"></activity>
         <receiver android:name="com.pichillilorenzo.flutter_inappwebview.ChromeCustomTabs.ActionBroadcastReceiver" />
+        <meta-data
+            android:name="io.flutter.embedded_views_preview"
+            android:value="true" />
     </application>
-
 </manifest>

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -85,5 +85,11 @@
                 android:resource="@xml/provider_paths"/>
         </provider>
 
+        <!-- Hybrid composition -->
+        <meta-data
+            android:name="io.flutter.embedded_views_preview"
+            android:value="true" />
+
+
     </application>
 </manifest>

--- a/lib/src/in_app_webview.dart
+++ b/lib/src/in_app_webview.dart
@@ -363,7 +363,9 @@ class _InAppWebViewState extends State<InAppWebView> {
                 'initialFile': widget.initialFile,
                 'initialData': widget.initialData?.toMap(),
                 'initialHeaders': widget.initialHeaders,
-                'initialOptions': widget.initialOptions?.toMap() ?? {}
+                'initialOptions': widget.initialOptions?.toMap() ?? {},
+                'contextMenu': widget.contextMenu?.toMap() ?? {},
+                'windowId': widget.windowId
               },
               creationParamsCodec: const StandardMessageCodec(),
             )

--- a/lib/src/in_app_webview.dart
+++ b/lib/src/in_app_webview.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/gestures.dart';
@@ -339,41 +340,37 @@ class _InAppWebViewState extends State<InAppWebView> {
   @override
   Widget build(BuildContext context) {
     if (defaultTargetPlatform == TargetPlatform.android) {
-      return AndroidView(
+      return PlatformViewLink(
         viewType: 'com.pichillilorenzo/flutter_inappwebview',
-        onPlatformViewCreated: _onPlatformViewCreated,
-        gestureRecognizers: widget.gestureRecognizers,
-        layoutDirection: TextDirection.rtl,
-        creationParams: <String, dynamic>{
-          'initialUrl': '${Uri.parse(widget.initialUrl)}',
-          'initialFile': widget.initialFile,
-          'initialData': widget.initialData?.toMap(),
-          'initialHeaders': widget.initialHeaders,
-          'initialOptions': widget.initialOptions?.toMap() ?? {},
-          'contextMenu': widget.contextMenu?.toMap() ?? {},
-          'windowId': widget.windowId
+        surfaceFactory: (
+            BuildContext context,
+            PlatformViewController controller,
+            ) {
+          return AndroidViewSurface(
+            controller: controller,
+            gestureRecognizers: widget.gestureRecognizers ?? const <Factory<OneSequenceGestureRecognizer>>{},
+            hitTestBehavior: PlatformViewHitTestBehavior.opaque,
+          );
         },
-        creationParamsCodec: const StandardMessageCodec(),
+        onCreatePlatformView: (PlatformViewCreationParams params) {
+          return PlatformViewsService.initSurfaceAndroidView(
+            id: params.id,
+            viewType: 'com.pichillilorenzo/flutter_inappwebview',
+            layoutDirection: TextDirection.rtl,
+            creationParams: <String, dynamic>{
+              'initialUrl': '${Uri.parse(widget.initialUrl)}',
+              'initialFile': widget.initialFile,
+              'initialData': widget.initialData?.toMap(),
+              'initialHeaders': widget.initialHeaders,
+              'initialOptions': widget.initialOptions?.toMap() ?? {}
+            },
+            creationParamsCodec: const StandardMessageCodec(),
+          )
+            ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
+            ..addOnPlatformViewCreatedListener((id) => _onPlatformViewCreated(id))
+            ..create();
+        },
       );
-      // onLongPress issue: https://github.com/flutter/plugins/blob/f31d16a6ca0c4bd6849cff925a00b6823973696b/packages/webview_flutter/lib/src/webview_android.dart#L31
-      /*return GestureDetector(
-        onLongPress: () {},
-        excludeFromSemantics: true,
-        child: AndroidView(
-          viewType: 'com.pichillilorenzo/flutter_inappwebview',
-          onPlatformViewCreated: _onPlatformViewCreated,
-          gestureRecognizers: widget.gestureRecognizers,
-          layoutDirection: TextDirection.rtl,
-          creationParams: <String, dynamic>{
-            'initialUrl': '${Uri.parse(widget.initialUrl)}',
-            'initialFile': widget.initialFile,
-            'initialData': widget.initialData?.toMap(),
-            'initialHeaders': widget.initialHeaders,
-            'initialOptions': initialOptions
-          },
-          creationParamsCodec: const StandardMessageCodec(),
-        ),
-      );*/
     } else if (defaultTargetPlatform == TargetPlatform.iOS) {
       return UiKitView(
         viewType: 'com.pichillilorenzo/flutter_inappwebview',

--- a/lib/src/in_app_webview.dart
+++ b/lib/src/in_app_webview.dart
@@ -340,37 +340,56 @@ class _InAppWebViewState extends State<InAppWebView> {
   @override
   Widget build(BuildContext context) {
     if (defaultTargetPlatform == TargetPlatform.android) {
-      return PlatformViewLink(
-        viewType: 'com.pichillilorenzo/flutter_inappwebview',
-        surfaceFactory: (
-            BuildContext context,
-            PlatformViewController controller,
-            ) {
-          return AndroidViewSurface(
-            controller: controller,
-            gestureRecognizers: widget.gestureRecognizers ?? const <Factory<OneSequenceGestureRecognizer>>{},
-            hitTestBehavior: PlatformViewHitTestBehavior.opaque,
-          );
-        },
-        onCreatePlatformView: (PlatformViewCreationParams params) {
-          return PlatformViewsService.initSurfaceAndroidView(
-            id: params.id,
-            viewType: 'com.pichillilorenzo/flutter_inappwebview',
-            layoutDirection: TextDirection.rtl,
-            creationParams: <String, dynamic>{
-              'initialUrl': '${Uri.parse(widget.initialUrl)}',
-              'initialFile': widget.initialFile,
-              'initialData': widget.initialData?.toMap(),
-              'initialHeaders': widget.initialHeaders,
-              'initialOptions': widget.initialOptions?.toMap() ?? {}
-            },
-            creationParamsCodec: const StandardMessageCodec(),
-          )
-            ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
-            ..addOnPlatformViewCreatedListener((id) => _onPlatformViewCreated(id))
-            ..create();
-        },
-      );
+      if (widget.initialOptions.android.useHybridComposition) {
+        return PlatformViewLink(
+          viewType: 'com.pichillilorenzo/flutter_inappwebview',
+          surfaceFactory: (
+              BuildContext context,
+              PlatformViewController controller,
+              ) {
+            return AndroidViewSurface(
+              controller: controller,
+              gestureRecognizers: widget.gestureRecognizers ?? const <Factory<OneSequenceGestureRecognizer>>{},
+              hitTestBehavior: PlatformViewHitTestBehavior.opaque,
+            );
+          },
+          onCreatePlatformView: (PlatformViewCreationParams params) {
+            return PlatformViewsService.initSurfaceAndroidView(
+              id: params.id,
+              viewType: 'com.pichillilorenzo/flutter_inappwebview',
+              layoutDirection: TextDirection.rtl,
+              creationParams: <String, dynamic>{
+                'initialUrl': '${Uri.parse(widget.initialUrl)}',
+                'initialFile': widget.initialFile,
+                'initialData': widget.initialData?.toMap(),
+                'initialHeaders': widget.initialHeaders,
+                'initialOptions': widget.initialOptions?.toMap() ?? {}
+              },
+              creationParamsCodec: const StandardMessageCodec(),
+            )
+              ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
+              ..addOnPlatformViewCreatedListener((id) => _onPlatformViewCreated(id))
+              ..create();
+          },
+        );
+      } else {
+        return AndroidView(
+          viewType: 'com.pichillilorenzo/flutter_inappwebview',
+          onPlatformViewCreated: _onPlatformViewCreated,
+          gestureRecognizers: widget.gestureRecognizers,
+          layoutDirection: TextDirection.rtl,
+          creationParams: <String, dynamic>{
+            'initialUrl': '${Uri.parse(widget.initialUrl)}',
+            'initialFile': widget.initialFile,
+            'initialData': widget.initialData?.toMap(),
+            'initialHeaders': widget.initialHeaders,
+            'initialOptions': widget.initialOptions?.toMap() ?? {},
+            'contextMenu': widget.contextMenu?.toMap() ?? {},
+            'windowId': widget.windowId
+          },
+          creationParamsCodec: const StandardMessageCodec(),
+        );
+      }
     } else if (defaultTargetPlatform == TargetPlatform.iOS) {
       return UiKitView(
         viewType: 'com.pichillilorenzo/flutter_inappwebview',

--- a/lib/src/webview_options.dart
+++ b/lib/src/webview_options.dart
@@ -470,6 +470,11 @@ class AndroidInAppWebViewOptions
   ///If the url request of a subframe matches the regular expression, then the request of that subframe is canceled.
   String regexToCancelSubFramesLoading;
 
+  ///Set to `true` to enable Flutter's new Hybrid Composition. The default value is `false`.
+  ///Hybrid Composition is supported starting with Flutter v1.20.
+  ///**NOTE**: It is recommended to use Hybrid Composition only on Android 10+ for a release app, as it can cause framerate drops on animations in Android 9 and lower.
+  bool useHybridComposition;
+
   ///Set to `true` to be able to listen at the [WebView.androidShouldInterceptRequest] event. The default value is `false`.
   bool useShouldInterceptRequest;
 
@@ -556,6 +561,7 @@ class AndroidInAppWebViewOptions
     this.initialScale = 0,
     this.supportMultipleWindows = false,
     this.regexToCancelSubFramesLoading,
+    this.useHybridComposition = false,
     this.useShouldInterceptRequest = false,
     this.useOnRenderProcessGone = false,
     this.overScrollMode = AndroidOverScrollMode.OVER_SCROLL_IF_CONTENT_SCROLLS,
@@ -613,6 +619,7 @@ class AndroidInAppWebViewOptions
       "thirdPartyCookiesEnabled": thirdPartyCookiesEnabled,
       "hardwareAcceleration": hardwareAcceleration,
       "supportMultipleWindows": supportMultipleWindows,
+      "useHybridComposition": useHybridComposition,
       "regexToCancelSubFramesLoading": regexToCancelSubFramesLoading,
       "useShouldInterceptRequest": useShouldInterceptRequest,
       "useOnRenderProcessGone": useOnRenderProcessGone,
@@ -676,6 +683,7 @@ class AndroidInAppWebViewOptions
     options.supportMultipleWindows = map["supportMultipleWindows"];
     options.regexToCancelSubFramesLoading =
         map["regexToCancelSubFramesLoading"];
+    options.useHybridComposition = map["useHybridComposition"];
     options.useShouldInterceptRequest = map["useShouldInterceptRequest"];
     options.useOnRenderProcessGone = map["useOnRenderProcessGone"];
     options.overScrollMode =


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue: https://github.com/flutter/flutter/issues/41089

**[webview_flutter] Keyboard language can't change on Android** (https://github.com/flutter/flutter/issues/41089) is listed in issue (https://github.com/flutter/flutter/issues/61133) and it's fixed by flutter PR: https://github.com/flutter/plugins/pull/2883

Although this issue is reported to webview_flutter, it happens in **flutter_inappwebview** too, and especially for users who use google gboard as input method, and try to switch to Chinese input methods.

So, I ported the fix from **webview_flutter** plugin.

## Testing and Review Notes

Steps:
* You have to change flutter channel to **dev** in order to build this PR, since the so-called hybrid composition is now only available for flutter v1.20 or v1.21.
* Install Google gboard input method, and install chinese pinyin or chuyin input method, and launch InAppWebView with some website that needs some input.
* focus on the text field and see if it's possible to switch to pinyin input method in gboard.

<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->


## Screenshots or Videos
**Video with language switching issue**
Before applying the fix, all Chinese input methods will be displayed with just QWERTY input keyboard, which does not allow users to input any Chinese characters.

![inappwebview_input_issue](https://user-images.githubusercontent.com/4084738/88531942-486aed80-d036-11ea-8224-4cf19fb68db5.gif)

**Video after applying the fix**
After applying the fix, the input method can be successfully switched, and be used to input Chinese.
![inappwebview_input_issue_fixed](https://user-images.githubusercontent.com/4084738/88531992-5de01780-d036-11ea-9f2e-99ef035a41ca.gif)

## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable)
