### PR TITLE
Added missing field 'headers' which returned by WebResourceResponse.toMap()

### DIFF
--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -272,6 +272,7 @@ class WebResourceResponse {
       "contentType": contentType,
       "contentEncoding": contentEncoding,
       "data": data,
+      "headers": headers,
       "statusCode": statusCode,
       "reasonPhrase": reasonPhrase
     };


### PR DESCRIPTION
When using `androidShouldInterceptRequest` to intercept request, and  responses data from dart to Java, the side on Java did't got the `headers` field.
This PR will fixed this issue.



## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable)
