### PR TITLE
Fix NullPointerException after taking a photo by a camera app on Android

### DIFF
--- a/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/InAppWebView/InAppWebViewChromeClient.java
+++ b/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/InAppWebView/InAppWebViewChromeClient.java
@@ -72,7 +72,7 @@ public class InAppWebViewChromeClient extends WebChromeClient implements PluginR
   private static final int PICKER = 1;
   private static final int PICKER_LEGACY = 3;
   final String DEFAULT_MIME_TYPES = "*/*";
-  private Uri outputFileUri;
+  private static Uri outputFileUri;
 
   protected static final FrameLayout.LayoutParams FULLSCREEN_LAYOUT_PARAMS = new FrameLayout.LayoutParams(
           ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT, Gravity.CENTER);


### PR DESCRIPTION
Fix NullPointerException after taking a photo by a camera app on Android.
You can reproduce this by setting up multiple inappwebviews and uploading photos.

## Connection with issue(s)

Resolve issue #487 

## Testing and Review Notes

## Screenshots or Videos

## To Do

- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable)
