### PR TITLE
Fixing wrong casting

### DIFF
--- a/ios/Classes/ChromeSafariBrowserManager.swift
+++ b/ios/Classes/ChromeSafariBrowserManager.swift
@@ -65,7 +65,7 @@ public class ChromeSafariBrowserManager: NSObject, FlutterPlugin {
         
         if #available(iOS 9.0, *) {
             
-            if let flutterViewController = UIApplication.shared.delegate?.window.unsafelyUnwrapped?.rootViewController as? FlutterViewController {
+            if let flutterViewController = UIApplication.shared.delegate?.window.unsafelyUnwrapped?.rootViewController {
                 let safariOptions = SafariBrowserOptions()
                 let _ = safariOptions.parse(options: options)
                 


### PR DESCRIPTION
I've modified rootViewController using UINavigationController. So It's not relevant to cast the rootViewController with FlutterViewController. It would be good to check the object null or not.

I've tested it, and it works fine both UINavigationController and FlutterViewController.