### PR TITLE
Added context menu option filterDefaultSystemContextMenuItems

### DIFF
--- a/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/InAppWebView/ContextMenuOptions.java
+++ b/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/InAppWebView/ContextMenuOptions.java
@@ -4,11 +4,13 @@ import com.pichillilorenzo.flutter_inappwebview.Options;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 
 public class ContextMenuOptions implements Options<Object> {
   public static final String LOG_TAG = "ContextMenuOptions";
 
   public Boolean hideDefaultSystemContextMenuItems = false;
+  public List<String> filterDefaultSystemContextMenuItems = null;
 
   public ContextMenuOptions parse(Map<String, Object> options) {
     for (Map.Entry<String, Object> pair : options.entrySet()) {
@@ -21,6 +23,9 @@ public class ContextMenuOptions implements Options<Object> {
       switch (key) {
         case "hideDefaultSystemContextMenuItems":
           hideDefaultSystemContextMenuItems = (Boolean) value;
+          break;
+        case "filterDefaultSystemContextMenuItems":
+          filterDefaultSystemContextMenuItems = (List<String>) value;
           break;
       }
     }

--- a/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/InAppWebView/InAppWebView.java
+++ b/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/InAppWebView/InAppWebView.java
@@ -1711,6 +1711,9 @@ final public class InAppWebView extends InputAwareWebView {
         final MenuItem menuItem = actionMenu.getItem(i);
         final int itemId = menuItem.getItemId();
         final String itemTitle = menuItem.getTitle().toString();
+        if (contextMenuOptions.filterDefaultSystemContextMenuItems != null && !contextMenuOptions.filterDefaultSystemContextMenuItems.contains(itemTitle)){
+          continue;
+        }
         TextView text = (TextView) LayoutInflater.from(this.getContext())
                 .inflate(R.layout.floating_action_mode_item, this, false);
         text.setText(itemTitle);

--- a/ios/Classes/ContextMenuOptions.swift
+++ b/ios/Classes/ContextMenuOptions.swift
@@ -10,6 +10,8 @@ import Foundation
 class ContextMenuOptions: Options<NSObject> {
     
     var hideDefaultSystemContextMenuItems = false;
+    // var filterDefaultSystemContextMenuItems = [String]();
+    var filterDefaultSystemContextMenuItems = nil;
 
     override init(){
         super.init()

--- a/ios/Classes/InAppWebView.swift
+++ b/ios/Classes/InAppWebView.swift
@@ -1040,6 +1040,9 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate, WKNavi
                     if !action.description.starts(with: "onContextMenuActionItemClicked-") && contextMenuOptions.hideDefaultSystemContextMenuItems {
                         return false
                     }
+                    if !contextMenuOptions.filterDefaultSystemContextMenuItems != nil && !contextMenuOptions.filterDefaultSystemContextMenuItems.contains(action.description) {
+                        return false;
+                    }
                 }
             }
             

--- a/lib/src/context_menu.dart
+++ b/lib/src/context_menu.dart
@@ -10,8 +10,7 @@ class ContextMenu {
   ///Event fired when the context menu for this WebView is being built.
   ///
   ///[hitTestResult] represents the hit result for hitting an HTML elements.
-  final void Function(InAppWebViewHitTestResult hitTestResult)
-      onCreateContextMenu;
+  final void Function(InAppWebViewHitTestResult hitTestResult) onCreateContextMenu;
 
   ///Event fired when the context menu for this WebView is being hidden.
   final void Function() onHideContextMenu;
@@ -19,8 +18,7 @@ class ContextMenu {
   ///Event fired when a context menu item has been clicked.
   ///
   ///[contextMenuItemClicked] represents the [ContextMenuItem] clicked.
-  final void Function(ContextMenuItem contextMenuItemClicked)
-      onContextMenuActionItemClicked;
+  final void Function(ContextMenuItem contextMenuItemClicked) onContextMenuActionItemClicked;
 
   ///Context menu options.
   final ContextMenuOptions options;
@@ -28,19 +26,11 @@ class ContextMenu {
   ///List of the custom [ContextMenuItem].
   final List<ContextMenuItem> menuItems;
 
-  ContextMenu(
-      {this.menuItems = const [],
-      this.onCreateContextMenu,
-      this.onHideContextMenu,
-      this.options,
-      this.onContextMenuActionItemClicked})
+  ContextMenu({this.menuItems = const [], this.onCreateContextMenu, this.onHideContextMenu, this.options, this.onContextMenuActionItemClicked})
       : assert(menuItems != null);
 
   Map<String, dynamic> toMap() {
-    return {
-      "menuItems": menuItems.map((menuItem) => menuItem?.toMap()).toList(),
-      "options": options?.toMap()
-    };
+    return {"menuItems": menuItems.map((menuItem) => menuItem?.toMap()).toList(), "options": options?.toMap()};
   }
 
   Map<String, dynamic> toJson() {
@@ -67,11 +57,7 @@ class ContextMenuItem {
   ///Menu item action that will be called when an user clicks on it.
   Function() action;
 
-  ContextMenuItem(
-      {@required this.androidId,
-      @required this.iosId,
-      @required this.title,
-      this.action});
+  ContextMenuItem({@required this.androidId, @required this.iosId, @required this.title, this.action});
 
   Map<String, dynamic> toMap() {
     return {"androidId": androidId, "iosId": iosId, "title": title};
@@ -92,11 +78,18 @@ class ContextMenuOptions {
   ///Whether all the default system context menu items should be hidden or not. The default value is `false`.
   bool hideDefaultSystemContextMenuItems;
 
-  ContextMenuOptions({this.hideDefaultSystemContextMenuItems = false});
+  ///List containing allowed system context menu items. The default value is `null`.
+  List<String> filterDefaultSystemContextMenuItems;
+
+  ContextMenuOptions({
+    this.hideDefaultSystemContextMenuItems = false,
+    this.filterDefaultSystemContextMenuItems = null,
+  });
 
   Map<String, dynamic> toMap() {
     return {
-      "hideDefaultSystemContextMenuItems": hideDefaultSystemContextMenuItems
+      "hideDefaultSystemContextMenuItems": hideDefaultSystemContextMenuItems,
+      "filterDefaultSystemContextMenuItems": filterDefaultSystemContextMenuItems,
     };
   }
 


### PR DESCRIPTION
## Customizable context menu

Added option "filterDefaultSystemContextMenuItems" in ContextMenuOptions.

## Purpose
When system context menu is visible (hideDefaultSystemContextMenuItems = false), using this option we can show only some of the default context menu items.

## Example:

If we need webview context menu to only show some items (Cut, Copy, Paste - whenever they are available), we can get rid of "Select all", "Dictionary", or any other items, like this:

```
_contextMenu = ContextMenu(
  options: ContextMenuOptions(
    hideDefaultSystemContextMenuItems: false,
    filterDefaultSystemContextMenuItems: ["Cut", "Copy", "Paste"],
  ),
);
```

## Testing and Review Notes

The option was added for both Android and IOS.
Tested only on Android.

## To Do

Nothing.
