### PR TITLE
Add android media intents on wildcard input accept

### DIFF
--- a/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/InAppWebView/InAppWebViewChromeClient.java
+++ b/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/InAppWebView/InAppWebViewChromeClient.java
@@ -1106,31 +1106,29 @@ public class InAppWebViewChromeClient extends WebChromeClient implements PluginR
     String prefix = "";
     String suffix = "";
     String dir = "";
-    String filename = "";
 
     if (intentType.equals(MediaStore.ACTION_IMAGE_CAPTURE)) {
-      prefix = "image-";
+      prefix = "image";
       suffix = ".jpg";
       dir = Environment.DIRECTORY_PICTURES;
     } else if (intentType.equals(MediaStore.ACTION_VIDEO_CAPTURE)) {
-      prefix = "video-";
+      prefix = "video";
       suffix = ".mp4";
       dir = Environment.DIRECTORY_MOVIES;
     }
-
-    filename = prefix + String.valueOf(System.currentTimeMillis()) + suffix;
 
     // for versions below 6.0 (23) we use the old File creation & permissions model
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
       // only this Directory works on all tested Android versions
       // ctx.getExternalFilesDir(dir) was failing on Android 5.0 (sdk 21)
       File storageDir = Environment.getExternalStoragePublicDirectory(dir);
+      String filename = String.format("%s-%d%s", prefix, System.currentTimeMillis(), suffix);
       return new File(storageDir, filename);
     }
 
     Activity activity = inAppBrowserActivity != null ? inAppBrowserActivity : Shared.activity;
     File storageDir = activity.getApplicationContext().getExternalFilesDir(null);
-    return File.createTempFile(filename, suffix, storageDir);
+    return File.createTempFile(prefix, suffix, storageDir);
   }
 
   private Boolean isArrayEmpty(String[] arr) {

--- a/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/InAppWebView/InAppWebViewChromeClient.java
+++ b/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/InAppWebView/InAppWebViewChromeClient.java
@@ -971,6 +971,20 @@ public class InAppWebViewChromeClient extends WebChromeClient implements PluginR
     return intent;
   }
 
+  private Boolean acceptsAny(String[] types) {
+    if (isArrayEmpty(types)) {
+      return true;
+    }
+
+    for (String type : types) {
+      if (type.equals("*/*")) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   private Boolean acceptsImages(String types) {
     String mimeType = types;
     if (types.matches("\\.\\w+")) {
@@ -981,7 +995,7 @@ public class InAppWebViewChromeClient extends WebChromeClient implements PluginR
 
   private Boolean acceptsImages(String[] types) {
     String[] mimeTypes = getAcceptedMimeType(types);
-    return isArrayEmpty(mimeTypes) || arrayContainsString(mimeTypes, "image");
+    return acceptsAny(types) || arrayContainsString(mimeTypes, "image");
   }
 
   private Boolean acceptsVideo(String types) {
@@ -994,7 +1008,7 @@ public class InAppWebViewChromeClient extends WebChromeClient implements PluginR
 
   private Boolean acceptsVideo(String[] types) {
     String[] mimeTypes = getAcceptedMimeType(types);
-    return isArrayEmpty(mimeTypes) || arrayContainsString(mimeTypes, "video");
+    return acceptsAny(types) || arrayContainsString(mimeTypes, "video");
   }
 
   private Boolean arrayContainsString(String[] array, String pattern) {

--- a/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/InAppWebView/InAppWebViewChromeClient.java
+++ b/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/InAppWebView/InAppWebViewChromeClient.java
@@ -843,12 +843,8 @@ public class InAppWebViewChromeClient extends WebChromeClient implements PluginR
   }
 
   private Uri[] getSelectedFiles(Intent data, int resultCode) {
-    if (data == null) {
-      return null;
-    }
-
     // we have one file selected
-    if (data.getData() != null) {
+    if (data != null && data.getData() != null) {
       if (resultCode == RESULT_OK && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
         return WebChromeClient.FileChooserParams.parseResult(resultCode, data);
       } else {
@@ -857,7 +853,7 @@ public class InAppWebViewChromeClient extends WebChromeClient implements PluginR
     }
 
     // we have multiple files selected
-    if (data.getClipData() != null) {
+    if (data != null && data.getClipData() != null) {
       final int numSelectedFiles = data.getClipData().getItemCount();
       Uri[] result = new Uri[numSelectedFiles];
       for (int i = 0; i < numSelectedFiles; i++) {


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #596 

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->

Connected to #596

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->

## Testing and Review Notes

<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->

1. Use the InAppWebView in an app with camera permissions.
2. Open a webpage with an `<input type="file">` (no accept attribute) in the InAppWebView.
3. The intent chooser should be shown with photo, video and file intents.

The following HTML can be used to test different accept parameters:
```html
<label>accept image/jpeg<input type="file" accept="image/jpeg"></label><br>
<label>accept video/mp4<input type="file" accept="video/mp4"></label><br>
<label>accept */*<input type="file" accept="*/*"></label><br>
<label>no accept (infers */*)<input type="file"></label>
```

## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers