### PR TITLE
Add support allowUniversalAccessFromFileURLs iOS

### DIFF
--- a/ios/Classes/InAppWebView.swift
+++ b/ios/Classes/InAppWebView.swift
@@ -1371,6 +1371,8 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate, WKNavi
                 configuration.dataDetectorTypes = dataDetectorTypes
                 
                 configuration.mediaTypesRequiringUserActionForPlayback = options.mediaPlaybackRequiresUserGesture ? .all : []
+                
+                configuration.setValue(options.allowUniversalAccessFromFileURLs, forKey: "allowUniversalAccessFromFileURLs")
             } else {
                 // Fallback on earlier versions
                 configuration.mediaPlaybackRequiresUserAction = options.mediaPlaybackRequiresUserGesture

--- a/ios/Classes/InAppWebViewOptions.swift
+++ b/ios/Classes/InAppWebViewOptions.swift
@@ -61,6 +61,8 @@ public class InAppWebViewOptions: Options<InAppWebView> {
     var minimumZoomScale = 1.0
     var contentInsetAdjustmentBehavior = 2 // UIScrollView.ContentInsetAdjustmentBehavior.never
     
+    var allowUniversalAccessFromFileURLs = false;
+    
     override init(){
         super.init()
     }

--- a/lib/src/webview_options.dart
+++ b/lib/src/webview_options.dart
@@ -945,7 +945,7 @@ class IOSInAppWebViewOptions
         IOSUIScrollViewContentInsetAdjustmentBehavior.fromValue(
             map["contentInsetAdjustmentBehavior"]);
     options.allowUniversalAccessFromFileURLs =
-        map["optioallowUniversalAccessFromFileURLsns"];
+        map["allowUniversalAccessFromFileURLs"];
     return options;
   }
 

--- a/lib/src/webview_options.dart
+++ b/lib/src/webview_options.dart
@@ -832,6 +832,9 @@ class IOSInAppWebViewOptions
   ///The default value is [IOSUIScrollViewContentInsetAdjustmentBehavior.NEVER].
   IOSUIScrollViewContentInsetAdjustmentBehavior contentInsetAdjustmentBehavior;
 
+  ///Set to true to support cross-domain. The default value is `false`.
+  bool allowUniversalAccessFromFileURLs;
+
   IOSInAppWebViewOptions(
       {this.disallowOverScroll = false,
       this.enableViewportScale = false,
@@ -856,7 +859,8 @@ class IOSInAppWebViewOptions
       this.maximumZoomScale = 1.0,
       this.minimumZoomScale = 1.0,
       this.contentInsetAdjustmentBehavior =
-          IOSUIScrollViewContentInsetAdjustmentBehavior.NEVER});
+          IOSUIScrollViewContentInsetAdjustmentBehavior.NEVER,
+      this.allowUniversalAccessFromFileURLs = false});
 
   @override
   Map<String, dynamic> toMap() {
@@ -891,7 +895,9 @@ class IOSInAppWebViewOptions
       "isPagingEnabled": isPagingEnabled,
       "maximumZoomScale": maximumZoomScale,
       "minimumZoomScale": minimumZoomScale,
-      "contentInsetAdjustmentBehavior": contentInsetAdjustmentBehavior.toValue()
+      "contentInsetAdjustmentBehavior":
+          contentInsetAdjustmentBehavior.toValue(),
+      "allowUniversalAccessFromFileURLs": allowUniversalAccessFromFileURLs
     };
   }
 
@@ -938,6 +944,8 @@ class IOSInAppWebViewOptions
     options.contentInsetAdjustmentBehavior =
         IOSUIScrollViewContentInsetAdjustmentBehavior.fromValue(
             map["contentInsetAdjustmentBehavior"]);
+    options.allowUniversalAccessFromFileURLs =
+        map["optioallowUniversalAccessFromFileURLsns"];
     return options;
   }
 


### PR DESCRIPTION
Add support allowUniversalAccessFromFileURLs iOS

fix [issues: 654](https://github.com/pichillilorenzo/flutter_inappwebview/issues/654)