### PR TITLE
iOS CookieManager.getCookies - Check that URL has suffix of cookie do…

### DIFF
--- a/ios/Classes/MyCookieManager.swift
+++ b/ios/Classes/MyCookieManager.swift
@@ -146,7 +146,7 @@ class MyCookieManager: NSObject, FlutterPlugin {
         if let urlHost = URL(string: url)?.host {
             MyCookieManager.httpCookieStore!.getAllCookies { (cookies) in
                 for cookie in cookies {
-                    if cookie.domain.contains(urlHost) {
+                    if urlHost.hasSuffix(cookie.domain) {
                         var sameSite: String? = nil
                         if #available(iOS 13.0, *) {
                             if let sameSiteValue = cookie.sameSitePolicy?.rawValue {


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #449

Connected to #510 #550 #573

## Testing and Review Notes

The linked issues are not detailed enough to be certain, but there is a bug in the iOS implementation of the CookieManager and the observed behaviors can be explained by this bug.

E.g. you have sites `api.example.com` and `www.example.com`. To create a cookie that is visible on both sites requires you to specify the domain as `.example.com` when calling setCookie.

So instead of checking whether cookie domain contains the host of the URL `".example.com".contains("www.example.com")`, we should check whether the cookie domain is the suffix of the current URL: `"www.example.com".hasSuffix(".example.com")`

Tested by using `onLoadStop` and visiting a bunch of webpages, comparing with desktop browser cookies.