### PR TITLE
[mod] Fix all issues relate to long click in Android version 7.0 (#657, #527)

### DIFF
--- a/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/InAppWebView/InAppWebView.java
+++ b/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/InAppWebView/InAppWebView.java
@@ -1966,7 +1966,7 @@ final public class InAppWebView extends InputAwareWebView {
       @Override
       public void onReceiveValue(String value) {
         if (floatingContextMenu != null) {
-          if (value != null && !value.equals("null")) {
+          if (value != null && !value.equalsIgnoreCase("null")) {
             int x = contextMenuPoint.x;
             int y = (int) ((Float.parseFloat(value) * scale) + (floatingContextMenu.getHeight() / 3.5));
             contextMenuPoint.y = y;
@@ -1986,7 +1986,7 @@ final public class InAppWebView extends InputAwareWebView {
     evaluateJavascript(getSelectedTextJS, new ValueCallback<String>() {
       @Override
       public void onReceiveValue(String value) {
-        value = (value != null) ? value.substring(1, value.length() - 1) : null;
+        value = (value != null && !value.equalsIgnoreCase("null")) ? value.substring(1, value.length() - 1) : null;
         resultCallback.onReceiveValue(value);
       }
     });


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #657, #527

This pull request focus on fix all issues relate to long click in Android version 7.0 (or bellow)
- Long click on image.
- Long click to select text.
- Long click on input field.

## Testing and Review Notes

#### Reproduce steps:
1. Open a screen with InAppWebView widget.
2. Load any url which included javascript you want.
3. Long click on to image/input field or select text.

#### Review Notes:
- Tested on Aquos (Android 7.0) and Samsung Galaxy (Android 7.0)

#### Confirm before fixxed:
```
02-06 19:24:33.532 22864 22864 V BoostFramework: BoostFramework() : mPerf = com.qualcomm.qti.Performance@8eb2b82
02-06 19:24:33.532 22864 22864 V BoostFramework: BoostFramework() : mPerf = com.qualcomm.qti.Performance@bef5293
02-06 19:24:33.641 22864 22864 W System.err: java.lang.NumberFormatException: For input string: "null" 
02-06 19:24:33.642 22864 22864 W System.err:     at java.lang.FloatingDecimal.readJavaFormatString(FloatingDecimal.java:1306)
02-06 19:24:33.642 22864 22864 W System.err:     at java.lang.Float.parseFloat(Float.java:459)
02-06 19:24:33.642 22864 22864 W System.err:     at com.pichillilorenzo.flutter_inappwebview.InAppWebView.InAppWebView$f.a()
02-06 19:24:33.642 22864 22864 W System.err:     at com.pichillilorenzo.flutter_inappwebview.InAppWebView.InAppWebView$f.onReceiveValue()
02-06 19:24:33.642 22864 22864 W System.err:     at org.chromium.android_webview.AwContents$8.handleJavaScriptResult(AwContents.java:2209)
02-06 19:24:33.642 22864 22864 W System.err:     at org.chromium.content.browser.webcontents.WebContentsImpl.onEvaluateJavaScriptResult(WebContentsImpl.java:349)
02-06 19:24:33.642 22864 22864 W System.err:     at org.chromium.base.SystemMessageHandler.nativeDoRunLoopOnce(Native Method)
02-06 19:24:33.642 22864 22864 W System.err:     at org.chromium.base.SystemMessageHandler.handleMessage(SystemMessageHandler.java:41)
02-06 19:24:33.642 22864 22864 W System.err:     at android.os.Handler.dispatchMessage(Handler.java:102)
02-06 19:24:33.642 22864 22864 W System.err:     at android.os.Looper.loop(Looper.java:154)
02-06 19:24:33.642 22864 22864 W System.err:     at android.app.ActivityThread.main(ActivityThread.java:6286)
02-06 19:24:33.642 22864 22864 W System.err:     at java.lang.reflect.Method.invoke(Native Method)
02-06 19:24:33.642 22864 22864 W System.err:     at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:869)
02-06 19:24:33.642 22864 22864 W System.err:     at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:759)
02-06 19:24:33.647 22864 22864 F chromium: [FATAL:jni_android.cc(236)] Please include Java exception stack in crash report
```