### PR TITLE
Make sure we open a new instance of a custom chrome chrome tab

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -8,7 +8,9 @@
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density" />
         <activity
             android:theme="@style/ThemeTransparent"
-            android:name="com.pichillilorenzo.flutter_inappwebview.chrome_custom_tabs.ChromeCustomTabsActivity" />
+            android:name="com.pichillilorenzo.flutter_inappwebview.chrome_custom_tabs.ChromeCustomTabsActivity"
+            android:launchMode="singleInstance"
+            />
         <receiver android:name="com.pichillilorenzo.flutter_inappwebview.chrome_custom_tabs.ActionBroadcastReceiver" />
         <meta-data
             android:name="io.flutter.embedded_views_preview"

--- a/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/chrome_custom_tabs/ChromeSafariBrowserManager.java
+++ b/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/chrome_custom_tabs/ChromeSafariBrowserManager.java
@@ -70,6 +70,9 @@ public class ChromeSafariBrowserManager implements MethodChannel.MethodCallHandl
     if (CustomTabActivityHelper.isAvailable(activity)) {
       intent = new Intent(activity, ChromeCustomTabsActivity.class);
       intent.putExtras(extras);
+      if ((boolean) options.get("noHistory")) {
+        intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+      }
       activity.startActivity(intent);
       result.success(true);
       return;

--- a/lib/src/chrome_safari_browser/android/chrome_custom_tabs_options.dart
+++ b/lib/src/chrome_safari_browser/android/chrome_custom_tabs_options.dart
@@ -35,6 +35,9 @@ class AndroidChromeCustomTabsOptions
   ///Set to `true` to enable Keep Alive. The default value is `false`.
   bool keepAliveEnabled;
 
+  //Set to `true` to launch the intent with the flag FLAG_ACTIVITY_NO_HISTORY
+  bool noHistory;
+
   AndroidChromeCustomTabsOptions(
       {this.addDefaultShareMenuItem = true,
       this.showTitle = true,
@@ -42,7 +45,9 @@ class AndroidChromeCustomTabsOptions
       this.enableUrlBarHiding = false,
       this.instantAppsEnabled = false,
       this.packageName,
-      this.keepAliveEnabled = false});
+      this.keepAliveEnabled = false,
+      this.noHistory = false
+      });
 
   @override
   Map<String, dynamic> toMap() {
@@ -53,7 +58,8 @@ class AndroidChromeCustomTabsOptions
       "enableUrlBarHiding": enableUrlBarHiding,
       "instantAppsEnabled": instantAppsEnabled,
       "packageName": packageName,
-      "keepAliveEnabled": keepAliveEnabled
+      "keepAliveEnabled": keepAliveEnabled,
+      "noHistory": noHistory
     };
   }
 
@@ -68,6 +74,7 @@ class AndroidChromeCustomTabsOptions
     options.instantAppsEnabled = map["instantAppsEnabled"];
     options.packageName = map["packageName"];
     options.keepAliveEnabled = map["keepAliveEnabled"];
+    options.noHistory = map["noHistory"];
     return options;
   }
 


### PR DESCRIPTION
This PR ensures that when we call .open(uri) on Android we are opening a fresh instance of Chrome Custom Tab.

Currently, when the user navigates back to the app using a deep link, the Chrome Custom Tab instance is not destroyed and when the user wants to launch a new instance they will find  themself inside an outdated instance with a wrong URL.