### PR TITLE
fix: use in NavigationAction request toMap method

### DIFF
--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -4052,7 +4052,7 @@ class NavigationAction {
 
   Map<String, dynamic> toMap() {
     return {
-      "request": request.toString(),
+      "request": request.toMap(),
       "isForMainFrame": isForMainFrame,
       "androidHasGesture": androidHasGesture,
       "androidIsRedirect": androidIsRedirect,


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #878

## Testing and Review Notes

The request object is not a string anymore:

`{"request":{"url":"https://www.google.com/","headers":null,"method":"GET","body":null,"iosAllowsCellularAccess":null,"iosAllowsConstrainedNetworkAccess":null,"iosAllowsExpensiveNetworkAccess":null,"iosCachePolicy":null,"iosHttpShouldHandleCookies":null,"iosHttpShouldUsePipelining":null,"iosNetworkServiceType":null,"iosTimeoutInterval":null,"iosMainDocumentURL":null},"isForMainFrame":true,"androidHasGesture":true,"androidIsRedirect":false,"iosWKNavigationType":null,"iosSourceFrame":null,"iosTargetFrame":null}`

## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable)
