### PR TITLE
switch android mockserver dependency with okhttp

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,7 +48,7 @@ android {
         implementation 'androidx.webkit:webkit:1.4.0'
         implementation 'androidx.browser:browser:1.3.0'
         implementation 'androidx.appcompat:appcompat:1.2.0'
-        implementation 'com.squareup.okhttp3:mockwebserver:3.14.7'
+        testImplementation 'com.squareup.okhttp3:mockwebserver:3.14.7'
         implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,7 +48,7 @@ android {
         implementation 'androidx.webkit:webkit:1.4.0'
         implementation 'androidx.browser:browser:1.3.0'
         implementation 'androidx.appcompat:appcompat:1.2.0'
-        testImplementation 'com.squareup.okhttp3:mockwebserver:3.14.7'
+        implementation 'com.squareup.okhttp3:okhttp:3.14.9'
         implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     }
 }


### PR DESCRIPTION
`flutter_inappwebview` can not be used within Android projects which also use mockserver > 3.14.7.  Looking at how this dependency is used; it seems to only be needed to supply the okhttp client for android.

This PR will switch from `mockserver` to `okhttp` and declare the dependency as `implementation` which should fix this issue and allow consuming applications more freedom from `mockserver` conflicts.

If `mockserver` is really needed for some reason; could we consider making it optional ; e.g. - `testImplementation`?
