### PR TITLE
Adds missing body to URLRequest mapping.

### DIFF
--- a/ios/Classes/Types/URLRequest.swift
+++ b/ios/Classes/Types/URLRequest.swift
@@ -63,6 +63,7 @@ extension URLRequest {
             "url": url?.absoluteString,
             "method": httpMethod,
             "headers": allHTTPHeaderFields,
+            "body": httpBody.map(FlutterStandardTypedData.init(bytes:)),
             "iosAllowsCellularAccess": allowsCellularAccess,
             "iosAllowsConstrainedNetworkAccess": iosAllowsConstrainedNetworkAccess,
             "iosAllowsExpensiveNetworkAccess": iosAllowsExpensiveNetworkAccess,


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #990

## Testing and Review Notes
1. Open a form which submits by sending a POST request.
2. Override the `shouldOverrideUrlLoading` handler and see that `navigationAction.request.body` is no longer null.

## To Do
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers

