### PR TITLE
fix. Crash happens when HeadlessInAppWebView's dispose function is called in iOS

### DIFF
--- a/ios/Classes/HeadlessInAppWebView/HeadlessInAppWebView.swift
+++ b/ios/Classes/HeadlessInAppWebView/HeadlessInAppWebView.swift
@@ -21,6 +21,10 @@ public class HeadlessInAppWebView : FlutterMethodCallDelegate {
         self.channel?.setMethodCallHandler(self.handle)
     }
     
+    deinit {
+        dispose()
+    }
+    
     public override func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         let arguments = call.arguments as? NSDictionary
         

--- a/ios/Classes/HeadlessInAppWebView/HeadlessInAppWebView.swift
+++ b/ios/Classes/HeadlessInAppWebView/HeadlessInAppWebView.swift
@@ -21,10 +21,6 @@ public class HeadlessInAppWebView : FlutterMethodCallDelegate {
         self.channel?.setMethodCallHandler(self.handle)
     }
     
-    deinit {
-        dispose()
-    }
-    
     public override func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         let arguments = call.arguments as? NSDictionary
         
@@ -95,5 +91,10 @@ public class HeadlessInAppWebView : FlutterMethodCallDelegate {
         channel = nil
         HeadlessInAppWebViewManager.webViews.removeValue(forKey: id)
         flutterWebView = nil
+    }
+    
+    deinit {
+        print("HeadlessInAppWebView - dealloc")
+        dispose()
     }
 }


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #881, #972

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->

Connected to #???

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->

## Testing and Review Notes

<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->


## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [ x ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable)
