### PR TITLE
Fixes URL returned when taping image with href in onCreateWindow [Android]

### DIFF
--- a/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/in_app_webview/InAppWebViewChromeClient.java
+++ b/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/in_app_webview/InAppWebViewChromeClient.java
@@ -573,6 +573,16 @@ public class InAppWebViewChromeClient extends WebChromeClient implements PluginR
     WebView.HitTestResult result = view.getHitTestResult();
     String url = result.getExtra();
 
+    // Ensure that images with hyperlink return the correct URL, not the image source
+    if(result.getType() == WebView.HitTestResult.SRC_IMAGE_ANCHOR_TYPE) {
+      Message href = view.getHandler().obtainMessage();
+      view.requestFocusNodeHref(href);
+      String imageUrl = href.getData().getString("url");
+      if(!imageUrl.isEmpty()) {
+        url = imageUrl;
+      }
+    }
+    
     URLRequest request = new URLRequest(url, "GET", null, null);
     CreateWindowAction createWindowAction = new CreateWindowAction(
             request,


### PR DESCRIPTION
## Connection with issue(s)

Resolves issue #951 

As explained in the issue, an image with a href link is returning the image source, not the intended URL. Therefore, a new window will open with just the image, not the page it was supposed to redirect. This PR introduces the fix explained in #951.
