### PR TITLE
Fix takeScreenshot Crash on iOS

### DIFF
--- a/ios/Classes/InAppWebView/InAppWebView.swift
+++ b/ios/Classes/InAppWebView/InAppWebView.swift
@@ -670,17 +670,17 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate, WKNavi
                     switch with["compressFormat"] as! String {
                     case "JPEG":
                         let quality = Float(with["quality"] as! Int) / 100
-                        imageData = screenshot.jpegData(compressionQuality: CGFloat(quality))!
+                        imageData = screenshot.jpegData(compressionQuality: CGFloat(quality))
                         break
                     case "PNG":
-                        imageData = screenshot.pngData()!
+                        imageData = screenshot.pngData()
                         break
                     default:
-                        imageData = screenshot.pngData()!
+                        imageData = screenshot.pngData()
                     }
                 }
                 else {
-                    imageData = screenshot.pngData()!
+                    imageData = screenshot.pngData()
                 }
             }
             completionHandler(imageData)


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue

Sometime the app will crash when calling takeScreenshot

## Testing and Review Notes

In the previous version, just try to take screenshot many times and the app will crash sometimes


## Screenshots or Videos

None

## To Do

None
