### PR TITLE
Feature. Possibility to disable iOS above keyboard inputAccessoryView

### DIFF
--- a/ios/Classes/InAppWebView/FlutterWebViewController.swift
+++ b/ios/Classes/InAppWebView/FlutterWebViewController.swift
@@ -58,6 +58,7 @@ public class FlutterWebViewController: NSObject, FlutterPlatformView {
                                    contextMenu: contextMenu,
                                    channel: channel!,
                                    userScripts: userScripts)
+            webView?.disableInputAccessoryView = options.disableInputAccessoryView
         }
         
         methodCallDelegate = InAppWebViewMethodHandler(webView: webView!)

--- a/ios/Classes/InAppWebView/InAppWebView.swift
+++ b/ios/Classes/InAppWebView/InAppWebView.swift
@@ -2942,10 +2942,9 @@ if(window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)] != null) {
     }
     
 //    var accessoryView: UIView?
-//
-//    // https://stackoverflow.com/a/58001395/4637638
-//    public override var inputAccessoryView: UIView? {
-//        // remove/replace the default accessory view
-//        return accessoryView
-//    }
+    var disableInputAccessoryView = false
+    // https://stackoverflow.com/a/58001395/4637638
+    public override var inputAccessoryView: UIView? {
+        return disableInputAccessoryView ? nil : super.inputAccessoryView
+    }
 }

--- a/ios/Classes/InAppWebView/InAppWebViewOptions.swift
+++ b/ios/Classes/InAppWebView/InAppWebViewOptions.swift
@@ -69,6 +69,7 @@ public class InAppWebViewOptions: Options<InAppWebView> {
     var applePayAPIEnabled = false
     var allowingReadAccessTo: String? = nil
     var disableLongPressContextMenuOnLinks = false
+    var disableInputAccessoryView = false
     
     override init(){
         super.init()

--- a/lib/src/in_app_webview/ios/in_app_webview_options.dart
+++ b/lib/src/in_app_webview/ios/in_app_webview_options.dart
@@ -223,6 +223,10 @@ class IOSInAppWebViewOptions
   ///The default value is `false`.
   bool disableLongPressContextMenuOnLinks;
 
+  ///Set to `true` to disable inputAccessoryView above system keyboard
+  ///https://developer.apple.com/documentation/uikit/uiresponder/1621119-inputaccessoryview
+  bool disableInputAccessoryView;
+
   IOSInAppWebViewOptions(
       {this.disallowOverScroll = false,
       this.enableViewportScale = false,
@@ -255,7 +259,8 @@ class IOSInAppWebViewOptions
       this.useOnNavigationResponse = false,
       this.applePayAPIEnabled = false,
       this.allowingReadAccessTo,
-      this.disableLongPressContextMenuOnLinks = false}) {
+      this.disableLongPressContextMenuOnLinks = false,
+      this.disableInputAccessoryView = false}) {
     assert(
         allowingReadAccessTo == null || allowingReadAccessTo!.isScheme("file"));
   }
@@ -303,6 +308,7 @@ class IOSInAppWebViewOptions
       "applePayAPIEnabled": applePayAPIEnabled,
       "allowingReadAccessTo": allowingReadAccessTo.toString(),
       "disableLongPressContextMenuOnLinks": disableLongPressContextMenuOnLinks,
+      "disableInputAccessoryView": disableInputAccessoryView,
     };
   }
 
@@ -365,6 +371,7 @@ class IOSInAppWebViewOptions
         : null;
     options.disableLongPressContextMenuOnLinks =
         map["disableLongPressContextMenuOnLinks"];
+    options.disableInputAccessoryView = map["disableInputAccessoryView"];
     return options;
   }
 


### PR DESCRIPTION
This PR adds possibility to disable iOS above keyboard inputAccessoryView with Done button.

I've found commented code & reused it to make things work.

## Screenshots or Videos
| With InputAccessoryView | Without InputAccessoryView |
| ------------- | ------------- |
| ![inputAccessoryView](https://user-images.githubusercontent.com/1662033/158806843-94670d45-110f-49ec-9df9-3840aea426eb.png)  | ![withoutInputAccessoryView](https://user-images.githubusercontent.com/1662033/158806991-ad879a26-6ca4-4c57-a065-12d7ac387123.jpg)  |
