### PR TITLE
[Android] Explicitly `export` for the receiver defined in AndroidManifest

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -25,7 +25,10 @@
             android:exported="true"
             android:name="com.pichillilorenzo.flutter_inappwebview.chrome_custom_tabs.TrustedWebActivitySingleInstance"
             android:launchMode="singleInstance"/>
-        <receiver android:name="com.pichillilorenzo.flutter_inappwebview.chrome_custom_tabs.ActionBroadcastReceiver" />
+        <receiver
+            android:name="com.pichillilorenzo.flutter_inappwebview.chrome_custom_tabs.ActionBroadcastReceiver"
+            android:enabled="true"
+            android:exported="false" />
         <meta-data
             android:name="io.flutter.embedded_views_preview"
             android:value="true" />


### PR DESCRIPTION
When targeting Android SDK 31+, all activities, receivers, etc, need to define an explicitly `export`. /cc @pichillilorenzo 