### PR TITLE
[Android] fix leaking `MethodChannel` through anonymous class

### DIFF
--- a/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/ServiceWorkerManager.java
+++ b/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/ServiceWorkerManager.java
@@ -168,13 +168,7 @@ public class ServiceWorkerManager implements MethodChannel.MethodCallHandler {
   }
 
   private ServiceWorkerClientCompat dummyServiceWorkerClientCompat() {
-    return new ServiceWorkerClientCompat() {
-      @Nullable
-      @Override
-      public WebResourceResponse shouldInterceptRequest(@NonNull WebResourceRequest request) {
-        return null;
-      }
-    };
+    return DummyServiceWorkerClientCompat.INSTANCE;
   }
 
   public void dispose() {
@@ -184,5 +178,15 @@ public class ServiceWorkerManager implements MethodChannel.MethodCallHandler {
       serviceWorkerController = null; 
     }
     plugin = null;
+  }
+
+  private static final class DummyServiceWorkerClientCompat extends ServiceWorkerClientCompat {
+    static final ServiceWorkerClientCompat INSTANCE = new DummyServiceWorkerClientCompat();
+
+    @Nullable
+    @Override
+    public WebResourceResponse shouldInterceptRequest(@NonNull WebResourceRequest request) {
+      return null;
+    }
   }
 }


### PR DESCRIPTION
anonymous class leaked ServiceWorkerManager -> MethodChannel which in turn leaks FlutterJNI
```
    ====================================
    HEAP ANALYSIS RESULT
    ====================================
    1 APPLICATION LEAKS
    
    References underlined with "~~~" are likely causes.
    Learn more at https://squ.re/leaks.
    
    10148702 bytes retained by leaking objects
    Signature: 3d5c9137904a59005331101308120bc8520c4bcd
    ┬───
    │ GC Root: Global variable in native code
    │
    ├─ org.chromium.android_webview.AwBrowserContext instance
    │    Leaking: UNKNOWN
    │    Retaining 33 B in 1 objects
    │    ↓ AwBrowserContext.c
    │                       ~
    ├─ pa instance
    │    Leaking: UNKNOWN
    │    Retaining 10.2 MB in 2051 objects
    │    ↓ pa.a
    │         ~
    ├─ ed0 instance
    │    Leaking: UNKNOWN
    │    Retaining 10.2 MB in 2048 objects
    │    ↓ ed0.a
    │          ~
    ├─ androidx.webkit.internal.FrameworkServiceWorkerClient instance
    │    Leaking: UNKNOWN
    │    Retaining 10.2 MB in 2047 objects
    │    ↓ FrameworkServiceWorkerClient.mImpl
    │                                   ~~~~~
    ├─ com.pichillilorenzo.flutter_inappwebview.ServiceWorkerManager$2 instance
    │    Leaking: UNKNOWN
    │    Retaining 10.2 MB in 2046 objects
    │    Anonymous subclass of androidx.webkit.ServiceWorkerClientCompat
    │    ↓ ServiceWorkerManager$2.this$0
    │                             ~~~~~~
    ├─ com.pichillilorenzo.flutter_inappwebview.ServiceWorkerManager instance
    │    Leaking: UNKNOWN
    │    Retaining 10.2 MB in 2045 objects
    │    ↓ ServiceWorkerManager.channel
    │                           ~~~~~~~
    ├─ io.flutter.plugin.common.MethodChannel instance
    │    Leaking: UNKNOWN
    │    Retaining 10.2 MB in 2044 objects
    │    ↓ MethodChannel.messenger
    │                    ~~~~~~~~~
    ├─ io.flutter.embedding.engine.dart.DartExecutor instance
    │    Leaking: UNKNOWN
    │    Retaining 10.2 MB in 2043 objects
    │    ↓ DartExecutor.flutterJNI
    │                   ~~~~~~~~~~
    ├─ io.flutter.embedding.engine.FlutterJNI instance
    │    Leaking: UNKNOWN
    │    Retaining 10.2 MB in 1649 objects
    │    ↓ FlutterJNI.localizationPlugin
    │                 ~~~~~~~~~~~~~~~~~~
    ├─ io.flutter.plugin.localization.LocalizationPlugin instance
    │    Leaking: UNKNOWN
    │    Retaining 10.1 MB in 1600 objects
    │    context instance of com.example.TestActivity with mDestroyed = true
    │    ↓ LocalizationPlugin.context
    │                         ~~~~~~~
    ╰→ com.example.TestActivity instance
    ​     Leaking: YES (ObjectWatcher was watching this because com.example.TestActivity received
    ​     Activity#onDestroy() callback and Activity#mDestroyed is true)
    ​     Retaining 10.1 MB in 1598 objects
    ​     key = 7b90c6de-3ca0-4deb-9772-2919d7815fa8
    ​     watchDurationMillis = 6891
    ​     retainedDurationMillis = 1847
    ​     mApplication instance of com.example.App
    ​     mBase instance of android.app.ContextImpl
    ====================================
```