### PR TITLE
fix: try to open with Chrome if default browser app does not support custom tabs

### DIFF
--- a/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/chrome_custom_tabs/CustomTabsHelper.java
+++ b/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/chrome_custom_tabs/CustomTabsHelper.java
@@ -6,6 +6,7 @@ import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
+import android.os.Build;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -59,7 +60,11 @@ public class CustomTabsHelper {
         }
 
         // Get all apps that can handle VIEW intents.
-        List<ResolveInfo> resolvedActivityList = pm.queryIntentActivities(activityIntent, 0);
+        int flags = 0;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            flags |= PackageManager.MATCH_ALL;
+        }
+        List<ResolveInfo> resolvedActivityList = pm.queryIntentActivities(activityIntent, flags);
         List<String> packagesSupportingCustomTabs = new ArrayList<>();
         for (ResolveInfo info : resolvedActivityList) {
             Intent serviceIntent = new Intent();

--- a/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/chrome_custom_tabs/CustomTabsHelper.java
+++ b/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/chrome_custom_tabs/CustomTabsHelper.java
@@ -53,6 +53,7 @@ public class CustomTabsHelper {
         PackageManager pm = context.getPackageManager();
         // Get default VIEW intent handler.
         Intent activityIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("http://www.example.com"));
+        activityIntent.addCategory(Intent.CATEGORY_BROWSABLE);
         ResolveInfo defaultViewHandlerInfo = pm.resolveActivity(activityIntent, 0);
         String defaultViewHandlerPackageName = null;
         if (defaultViewHandlerInfo != null) {


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #1232

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->

## Testing and Review Notes

<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->

1. Install browser app which does not support custom tabs such as Sleipnir
https://play.google.com/store/apps/details?id=jp.co.fenrir.android.sleipnir

2. Set installed browser as a default browser app by setting app

3. Try to open URL by ChromeSafariBrowser

4. Before this fix, cannot open URL
After this fix, can open URL by Chrome  

## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable)
