### PR TITLE
fix: Prevent Android java.lang.NullPointerException in InAppWebViewCl…

### DIFF
--- a/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/in_app_webview/InAppWebViewClient.java
+++ b/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/in_app_webview/InAppWebViewClient.java
@@ -331,7 +331,9 @@ public class InAppWebViewClient extends WebViewClient {
 
     URI uri;
     try {
-      uri = new URI(view.getUrl());
+      String url = view.getUrl();
+      if (url == null) return;
+      uri = new URI(url);
     } catch (URISyntaxException e) {
       e.printStackTrace();
 

--- a/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/in_app_webview/InAppWebViewClient.java
+++ b/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/in_app_webview/InAppWebViewClient.java
@@ -328,33 +328,21 @@ public class InAppWebViewClient extends WebViewClient {
 
   @Override
   public void onReceivedHttpAuthRequest(final WebView view, final HttpAuthHandler handler, final String host, final String realm) {
-
-    URI uri;
-    try {
-      String url = view.getUrl();
-      if (url == null) return;
-      uri = new URI(url);
-    } catch (URISyntaxException e) {
-      e.printStackTrace();
-
-      credentialsProposed = null;
-      previousAuthRequestFailureCount = 0;
-
-      handler.cancel();
-      return;
+    final String url = view.getUrl();
+    String protocol = "https";
+    int port = 0;
+    
+    if (url != null) {
+      try {
+        URI uri = new URI(url);
+        protocol = uri.getScheme();
+        port = uri.getPort();
+      } catch (URISyntaxException e) {
+        e.printStackTrace();
+      }
     }
 
-    final String protocol = uri.getScheme();
-    final int port = uri.getPort();
-
     previousAuthRequestFailureCount++;
-
-    Map<String, Object> obj = new HashMap<>();
-    obj.put("host", host);
-    obj.put("protocol", protocol);
-    obj.put("realm", realm);
-    obj.put("port", port);
-    obj.put("previousFailureCount", previousAuthRequestFailureCount);
 
     if (credentialsProposed == null)
       credentialsProposed = CredentialDatabase.getInstance(view.getContext()).getHttpAuthCredentials(host, protocol, realm, port);
@@ -367,6 +355,8 @@ public class InAppWebViewClient extends WebViewClient {
     URLProtectionSpace protectionSpace = new URLProtectionSpace(host, protocol, realm, port, view.getCertificate(), null);
     HttpAuthenticationChallenge challenge = new HttpAuthenticationChallenge(protectionSpace, previousAuthRequestFailureCount, credentialProposed);
 
+    final String finalProtocol = protocol;
+    final int finalPort = port;
     channel.invokeMethod("onReceivedHttpAuthRequest", challenge.toMap(), new MethodChannel.Result() {
       @Override
       public void success(Object response) {
@@ -380,7 +370,7 @@ public class InAppWebViewClient extends WebViewClient {
                 String password = (String) responseMap.get("password");
                 Boolean permanentPersistence = (Boolean) responseMap.get("permanentPersistence");
                 if (permanentPersistence != null && permanentPersistence) {
-                  CredentialDatabase.getInstance(view.getContext()).setHttpAuthCredential(host, protocol, realm, port, username, password);
+                  CredentialDatabase.getInstance(view.getContext()).setHttpAuthCredential(host, finalProtocol, realm, finalPort, username, password);
                 }
                 handler.proceed(username, password);
                 return;
@@ -421,19 +411,20 @@ public class InAppWebViewClient extends WebViewClient {
 
   @Override
   public void onReceivedSslError(final WebView view, final SslErrorHandler handler, final SslError sslError) {
-    URI uri;
+    final String url = sslError.getUrl();
+    String host = "";
+    String protocol = "https";
+    final String realm = null;
+    int port = 0;
+
     try {
-      uri = new URI(sslError.getUrl());
+      URI uri = new URI(url);
+      host = uri.getHost();
+      protocol = uri.getScheme();
+      port = uri.getPort();
     } catch (URISyntaxException e) {
       e.printStackTrace();
-      handler.cancel();
-      return;
     }
-
-    final String host = uri.getHost();
-    final String protocol = uri.getScheme();
-    final String realm = null;
-    final int port = uri.getPort();
 
     URLProtectionSpace protectionSpace = new URLProtectionSpace(host, protocol, realm, port, sslError.getCertificate(), sslError);
     ServerTrustChallenge challenge = new ServerTrustChallenge(protectionSpace);
@@ -475,22 +466,20 @@ public class InAppWebViewClient extends WebViewClient {
   @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
   @Override
   public void onReceivedClientCertRequest(final WebView view, final ClientCertRequest request) {
-
-    InAppWebView webView = (InAppWebView) view;
-
-    URI uri;
-    try {
-      uri = new URI(view.getUrl());
-    } catch (URISyntaxException e) {
-      e.printStackTrace();
-      request.cancel();
-      return;
-    }
-
+    final String url = view.getUrl();
     final String host = request.getHost();
-    final String protocol = uri.getScheme();
+    String protocol = "https";
     final String realm = null;
     final int port = request.getPort();
+
+    if (url != null) {
+      try {
+        URI uri = new URI(url);
+        protocol = uri.getScheme();
+      } catch (URISyntaxException e) {
+        e.printStackTrace();
+      }
+    }
 
     URLProtectionSpace protectionSpace = new URLProtectionSpace(host, protocol, realm, port, view.getCertificate(), null);
     ClientCertChallenge challenge = new ClientCertChallenge(protectionSpace, request.getPrincipals(), request.getKeyTypes());


### PR DESCRIPTION
…ient.onReceivedHttpAuthRequest view.getUrl()

## Connection with issue(s)

Resolve issue
Android Oreo 8.1 crash when an app uses HttpAuth.

## Testing and Review Notes

I was able to reproduce it on Android Emulator with 8.1 and on some Soucelab devices (LG and Redmi, but not Samsung for example). After some tries, the web view manages to load. But then the device needs a restart and it will happen again.
I wasn't able to replicate it on any other OS.
 
## Screenshots or Videos

I have a crash log from a console.
```
W/System.err( 3845): java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.String.length()' on a null object reference
W/System.err( 3845): 	at java.net.URI$Parser.parse(URI.java:3069)
W/System.err( 3845): 	at java.net.URI.<init>(URI.java:583)
W/System.err( 3845): 	at com.pichillilorenzo.flutter_inappwebview.in_app_webview.InAppWebViewClient.onReceivedHttpAuthRequest(InAppWebViewClient.java:334)
W/System.err( 3845): 	at com.android.webview.chromium.WebViewContentsClientAdapter.onReceivedHttpAuthRequest(WebViewContentsClientAdapter.java:420)
W/System.err( 3845): 	at org.chromium.android_webview.AwContents.onReceivedHttpAuthRequest(AwContents.java:690)
W/System.err( 3845): 	at org.chromium.base.SystemMessageHandler.nativeDoRunLoopOnce(Native Method)
W/System.err( 3845): 	at org.chromium.base.SystemMessageHandler.handleMessage(SystemMessageHandler.java:7)
W/System.err( 3845): 	at android.os.Handler.dispatchMessage(Handler.java:106)
W/System.err( 3845): 	at android.os.Looper.loop(Looper.java:164)
W/System.err( 3845): 	at android.app.ActivityThread.main(ActivityThread.java:6494)
W/System.err( 3845): 	at java.lang.reflect.Method.invoke(Native Method)
W/System.err( 3845): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
W/System.err( 3845): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)
```
Also, as documented https://developer.android.com/reference/android/webkit/WebView `getUrl()` can return null, but it wasn't checked in the code.
