### PR TITLE
Implement requestDeviceOrientationAndMotionPermissionfor iOS 15+

### DIFF
--- a/ios/Classes/InAppWebView/FlutterWebViewController.swift
+++ b/ios/Classes/InAppWebView/FlutterWebViewController.swift
@@ -37,8 +37,8 @@ public class FlutterWebViewController: NSObject, FlutterPlatformView {
         
         var userScripts: [UserScript] = []
         if let initialUserScripts = initialUserScripts {
-            for intialUserScript in initialUserScripts {
-                userScripts.append(UserScript.fromMap(map: intialUserScript, windowId: windowId)!)
+            for initialUserScript in initialUserScripts {
+                userScripts.append(UserScript.fromMap(map: initialUserScript, windowId: windowId)!)
             }
         }
         

--- a/ios/Classes/InAppWebView/InAppWebView.swift
+++ b/ios/Classes/InAppWebView/InAppWebView.swift
@@ -2218,7 +2218,15 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate, WKNavi
                         didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!) {
         onDidReceiveServerRedirectForProvisionalNavigation()
     }
-    
+
+    @available(iOS 15.0, *)
+    public func webView(_ webView: WKWebView,
+                        requestDeviceOrientationAndMotionPermissionFor origin: WKSecurityOrigin,
+                        initiatedByFrame frame: WKFrameInfo,
+                        decisionHandler: @escaping (WKPermissionDecision) -> Void) {
+         decisionHandler(WKPermissionDecision.init(rawValue: self.options!.deviceOrientationAndMotionPermission)!)
+     }
+
 //    @available(iOS 13.0, *)
 //    public func webView(_ webView: WKWebView,
 //                        contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo,

--- a/ios/Classes/InAppWebView/InAppWebViewOptions.swift
+++ b/ios/Classes/InAppWebView/InAppWebViewOptions.swift
@@ -48,6 +48,7 @@ public class InAppWebViewOptions: Options<InAppWebView> {
     var allowsPictureInPictureMediaPlayback = true
     var isFraudulentWebsiteWarningEnabled = true;
     var selectionGranularity = 0;
+    var deviceOrientationAndMotionPermission = 2;
     var dataDetectorTypes: [String] = ["NONE"] // WKDataDetectorTypeNone
     var preferredContentMode = 0
     var sharedCookiesEnabled = false
@@ -112,6 +113,7 @@ public class InAppWebViewOptions: Options<InAppWebView> {
                 realOptions["automaticallyAdjustsScrollIndicatorInsets"] = webView.scrollView.automaticallyAdjustsScrollIndicatorInsets
             }
             realOptions["selectionGranularity"] = configuration.selectionGranularity.rawValue
+            realOptions["deviceOrientationAndMotionPermission"] = webView.options!.deviceOrientationAndMotionPermission
             if #available(iOS 11.0, *) {
                 realOptions["accessibilityIgnoresInvertColors"] = webView.accessibilityIgnoresInvertColors
                 realOptions["contentInsetAdjustmentBehavior"] = webView.scrollView.contentInsetAdjustmentBehavior.rawValue

--- a/ios/Classes/InAppWebViewStatic.swift
+++ b/ios/Classes/InAppWebViewStatic.swift
@@ -54,7 +54,7 @@ class InAppWebViewStatic: NSObject, FlutterPlugin {
             InAppWebViewStatic.webViewForUserAgent?.evaluateJavaScript("navigator.userAgent") { (value, error) in
 
                 if error != nil {
-                    print("Error occured to get userAgent")
+                    print("Error occurred to get userAgent")
                     self.webViewForUserAgent = nil
                     completionHandler(nil)
                     return

--- a/lib/src/in_app_webview/ios/in_app_webview_options.dart
+++ b/lib/src/in_app_webview/ios/in_app_webview_options.dart
@@ -55,6 +55,16 @@ class IOSInAppWebViewOptions
   ///The default value is [IOSWKSelectionGranularity.DYNAMIC]
   IOSWKSelectionGranularity selectionGranularity;
 
+  ///The permission decisions for device orientation and motion access in the web view.
+  ///The default value is [IOSWKPermissionDecision.PROMPT]
+  ///
+  ///The website still needs to request the permission in javascipt via
+  ///`DeviceMotionEvent.requestPermission()` - alternativly this can be done manually
+  ///in the [InAppWebView.onLoadStop] callback.
+  ///
+  ///**NOTE**: available on iOS 15.0+.
+  IOSWKPermissionDecision deviceOrientationAndMotionPermission;
+
   ///Specifying a dataDetectoryTypes value adds interactivity to web content that matches the value.
   ///For example, Safari adds a link to “apple.com” in the text “Visit apple.com” if the dataDetectorTypes property is set to [IOSWKDataDetectorTypes.LINK].
   ///The default value is [IOSWKDataDetectorTypes.NONE].
@@ -239,6 +249,7 @@ class IOSInAppWebViewOptions
       this.allowsPictureInPictureMediaPlayback = true,
       this.isFraudulentWebsiteWarningEnabled = true,
       this.selectionGranularity = IOSWKSelectionGranularity.DYNAMIC,
+      this.deviceOrientationAndMotionPermission = IOSWKPermissionDecision.PROMPT,
       this.dataDetectorTypes = const [IOSWKDataDetectorTypes.NONE],
       this.sharedCookiesEnabled = false,
       this.automaticallyAdjustsScrollIndicatorInsets = false,
@@ -286,6 +297,7 @@ class IOSInAppWebViewOptions
           allowsPictureInPictureMediaPlayback,
       "isFraudulentWebsiteWarningEnabled": isFraudulentWebsiteWarningEnabled,
       "selectionGranularity": selectionGranularity.toValue(),
+      "deviceOrientationAndMotionPermission": deviceOrientationAndMotionPermission.toValue(),
       "dataDetectorTypes": dataDetectorTypesList,
       "sharedCookiesEnabled": sharedCookiesEnabled,
       "automaticallyAdjustsScrollIndicatorInsets":
@@ -342,6 +354,8 @@ class IOSInAppWebViewOptions
         map["isFraudulentWebsiteWarningEnabled"];
     options.selectionGranularity =
         IOSWKSelectionGranularity.fromValue(map["selectionGranularity"])!;
+    options.deviceOrientationAndMotionPermission =
+        IOSWKPermissionDecision.fromValue(map["deviceOrientationAndMotionPermission"])!;
     options.dataDetectorTypes = dataDetectorTypes;
     options.sharedCookiesEnabled = map["sharedCookiesEnabled"];
     options.automaticallyAdjustsScrollIndicatorInsets =

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -2232,6 +2232,60 @@ class IOSWKSelectionGranularity {
   int get hashCode => _value.hashCode;
 }
 
+
+///An iOS-15+ specific class used to set possible permission decisions for device resource access in the web view.
+///Based on https://developer.apple.com/documentation/webkit/wkpermissiondecision
+class IOSWKPermissionDecision {
+  final int _value;
+
+  const IOSWKPermissionDecision._internal(this._value);
+
+  static final Set<IOSWKPermissionDecision> values = [
+    IOSWKPermissionDecision.DENY,
+    IOSWKPermissionDecision.GRANT,
+    IOSWKPermissionDecision.PROMPT,
+  ].toSet();
+
+  static IOSWKPermissionDecision? fromValue(int? value) {
+    if (value != null) {
+      try {
+        return IOSWKPermissionDecision.values
+            .firstWhere((element) => element.toValue() == value);
+      } catch (e) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  int toValue() => _value;
+
+  @override
+  String toString() {
+    switch (_value) {
+      case 1:
+        return "CHARACTER";
+      case 0:
+      default:
+        return "DYNAMIC";
+    }
+  }
+
+  ///Deny resource access
+  static const DENY = const IOSWKPermissionDecision._internal(0);
+
+  ///Grant resource access
+  static const GRANT = const IOSWKPermissionDecision._internal(1);
+
+  ///Prompt to grant resource access
+  static const PROMPT = const IOSWKPermissionDecision._internal(2);
+
+  bool operator ==(value) => value == _value;
+
+  @override
+  int get hashCode => _value.hashCode;
+}
+
 ///An iOS-specific class used to specify a `dataDetectoryTypes` value that adds interactivity to web content that matches the value.
 ///
 ///**NOTE**: available on iOS 10.0+.


### PR DESCRIPTION
## Connection with issue(s)

fixes #838 


## Testing and Review Notes

On a normal HTTPS web pages a prompt will be shown when try to access the sensor events.
On a local/http/file-url web page sensor events are not support, no prompt is showing up since iOS13?. The permission can no be request or granted.

With this change a [WKPermissionDecision](https://developer.apple.com/documentation/webkit/wkpermissiondecision) can be configured for iOS 15+ to automatically grant, deny or prompt for access.


## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable)
