### PR TITLE
remove deprecated android.webkit.WebSettings setAppCachePath and setAppCacheEnab…

### DIFF
--- a/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/in_app_webview/InAppWebView.java
+++ b/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/in_app_webview/InAppWebView.java
@@ -275,9 +275,6 @@ final public class InAppWebView extends InputAwareWebView implements InAppWebVie
     settings.setAllowFileAccess(options.allowFileAccess);
     settings.setAllowFileAccessFromFileURLs(options.allowFileAccessFromFileURLs);
     settings.setAllowUniversalAccessFromFileURLs(options.allowUniversalAccessFromFileURLs);
-    setCacheEnabled(options.cacheEnabled);
-    if (options.appCachePath != null && !options.appCachePath.isEmpty() && options.cacheEnabled)
-      settings.setAppCachePath(options.appCachePath);
     settings.setBlockNetworkImage(options.blockNetworkImage);
     settings.setBlockNetworkLoads(options.blockNetworkLoads);
     if (options.cacheMode != null)
@@ -491,7 +488,6 @@ final public class InAppWebView extends InputAwareWebView implements InAppWebVie
 
       // Disable caching
       settings.setCacheMode(WebSettings.LOAD_NO_CACHE);
-      settings.setAppCacheEnabled(false);
       clearHistory();
       clearCache(true);
 
@@ -501,24 +497,8 @@ final public class InAppWebView extends InputAwareWebView implements InAppWebVie
       settings.setSaveFormData(false);
     } else {
       settings.setCacheMode(WebSettings.LOAD_DEFAULT);
-      settings.setAppCacheEnabled(true);
       settings.setSavePassword(true);
       settings.setSaveFormData(true);
-    }
-  }
-
-  public void setCacheEnabled(boolean enabled) {
-    WebSettings settings = getSettings();
-    if (enabled) {
-      Context ctx = getContext();
-      if (ctx != null) {
-        settings.setAppCachePath(ctx.getCacheDir().getAbsolutePath());
-        settings.setCacheMode(WebSettings.LOAD_DEFAULT);
-        settings.setAppCacheEnabled(true);
-      }
-    } else {
-      settings.setCacheMode(WebSettings.LOAD_NO_CACHE);
-      settings.setAppCacheEnabled(false);
     }
   }
 
@@ -759,12 +739,6 @@ final public class InAppWebView extends InputAwareWebView implements InAppWebVie
 
     if (newOptionsMap.get("allowUniversalAccessFromFileURLs") != null && options.allowUniversalAccessFromFileURLs != newOptions.allowUniversalAccessFromFileURLs)
       settings.setAllowUniversalAccessFromFileURLs(newOptions.allowUniversalAccessFromFileURLs);
-
-    if (newOptionsMap.get("cacheEnabled") != null && options.cacheEnabled != newOptions.cacheEnabled)
-      setCacheEnabled(newOptions.cacheEnabled);
-
-    if (newOptionsMap.get("appCachePath") != null && (options.appCachePath == null || !options.appCachePath.equals(newOptions.appCachePath)))
-      settings.setAppCachePath(newOptions.appCachePath);
 
     if (newOptionsMap.get("blockNetworkImage") != null && options.blockNetworkImage != newOptions.blockNetworkImage)
       settings.setBlockNetworkImage(newOptions.blockNetworkImage);

--- a/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/in_app_webview/InAppWebViewOptions.java
+++ b/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/in_app_webview/InAppWebViewOptions.java
@@ -40,7 +40,6 @@ public class InAppWebViewOptions implements Options<InAppWebViewInterface> {
   public Boolean useShouldInterceptAjaxRequest = false;
   public Boolean useShouldInterceptFetchRequest = false;
   public Boolean incognito = false;
-  public Boolean cacheEnabled = true;
   public Boolean transparentBackground = false;
   public Boolean disableVerticalScroll = false;
   public Boolean disableHorizontalScroll = false;
@@ -60,7 +59,6 @@ public class InAppWebViewOptions implements Options<InAppWebViewInterface> {
   public Integer mixedContentMode;
   public Boolean allowContentAccess = true;
   public Boolean allowFileAccess = true;
-  public String appCachePath;
   public Boolean blockNetworkImage = false;
   public Boolean blockNetworkLoads = false;
   public Integer cacheMode = WebSettings.LOAD_DEFAULT;
@@ -173,9 +171,6 @@ public class InAppWebViewOptions implements Options<InAppWebViewInterface> {
         case "incognito":
           incognito = (Boolean) value;
           break;
-        case "cacheEnabled":
-          cacheEnabled = (Boolean) value;
-          break;
         case "transparentBackground":
           transparentBackground = (Boolean) value;
           break;
@@ -229,9 +224,6 @@ public class InAppWebViewOptions implements Options<InAppWebViewInterface> {
           break;
         case "allowUniversalAccessFromFileURLs":
           allowUniversalAccessFromFileURLs = (Boolean) value;
-          break;
-        case "appCachePath":
-          appCachePath = (String) value;
           break;
         case "blockNetworkImage":
           blockNetworkImage = (Boolean) value;
@@ -389,7 +381,6 @@ public class InAppWebViewOptions implements Options<InAppWebViewInterface> {
     options.put("useShouldInterceptAjaxRequest", useShouldInterceptAjaxRequest);
     options.put("useShouldInterceptFetchRequest", useShouldInterceptFetchRequest);
     options.put("incognito", incognito);
-    options.put("cacheEnabled", cacheEnabled);
     options.put("transparentBackground", transparentBackground);
     options.put("disableVerticalScroll", disableVerticalScroll);
     options.put("disableHorizontalScroll", disableHorizontalScroll);
@@ -408,7 +399,6 @@ public class InAppWebViewOptions implements Options<InAppWebViewInterface> {
     options.put("allowFileAccess", allowFileAccess);
     options.put("allowFileAccessFromFileURLs", allowFileAccessFromFileURLs);
     options.put("allowUniversalAccessFromFileURLs", allowUniversalAccessFromFileURLs);
-    options.put("appCachePath", appCachePath);
     options.put("blockNetworkImage", blockNetworkImage);
     options.put("blockNetworkLoads", blockNetworkLoads);
     options.put("cacheMode", cacheMode);

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -30,7 +30,7 @@ android {
         targetCompatibility 1.8
     }
 
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     lintOptions {
         disable 'InvalidPackage'
@@ -39,7 +39,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.pichillilorenzo.flutter_inappwebviewexample"
-        minSdkVersion 17
+        minSdkVersion 19
         targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   cupertino_icons: ^1.0.4
   flutter_downloader: ^1.7.3
   path_provider: ^2.0.9
-  permission_handler: ^9.2.0
+  permission_handler: ^10.0.0
   url_launcher: ^6.0.20
   # connectivity: ^0.4.5+6
   flutter_inappwebview:

--- a/lib/src/in_app_webview/android/in_app_webview_options.dart
+++ b/lib/src/in_app_webview/android/in_app_webview_options.dart
@@ -2,10 +2,8 @@ import 'dart:ui';
 
 import 'package:flutter_inappwebview/src/util.dart';
 
-import '../../types.dart';
-
 import '../../in_app_browser/in_app_browser_options.dart';
-
+import '../../types.dart';
 import '../in_app_webview_options.dart';
 import '../webview.dart';
 
@@ -55,10 +53,6 @@ class AndroidInAppWebViewOptions
   ///Enables or disables file access within WebView. Note that this enables or disables file system access only.
   ///Assets and resources are still accessible using `file:///android_asset` and `file:///android_res`. The default value is `true`.
   bool allowFileAccess;
-
-  ///Sets the path to the Application Caches files. In order for the Application Caches API to be enabled, this option must be set a path to which the application can write.
-  ///This option is used one time: repeated calls are ignored.
-  String? appCachePath;
 
   ///Sets whether the WebView should not load image resources from the network (resources accessed via http and https URI schemes). The default value is `false`.
   bool blockNetworkImage;
@@ -251,7 +245,6 @@ class AndroidInAppWebViewOptions
     this.mixedContentMode,
     this.allowContentAccess = true,
     this.allowFileAccess = true,
-    this.appCachePath,
     this.blockNetworkImage = false,
     this.blockNetworkLoads = false,
     this.cacheMode = AndroidCacheMode.LOAD_DEFAULT,
@@ -312,7 +305,6 @@ class AndroidInAppWebViewOptions
       "mixedContentMode": mixedContentMode?.toValue(),
       "allowContentAccess": allowContentAccess,
       "allowFileAccess": allowFileAccess,
-      "appCachePath": appCachePath,
       "blockNetworkImage": blockNetworkImage,
       "blockNetworkLoads": blockNetworkLoads,
       "cacheMode": cacheMode?.toValue(),
@@ -373,7 +365,6 @@ class AndroidInAppWebViewOptions
         AndroidMixedContentMode.fromValue(map["mixedContentMode"]);
     options.allowContentAccess = map["allowContentAccess"];
     options.allowFileAccess = map["allowFileAccess"];
-    options.appCachePath = map["appCachePath"];
     options.blockNetworkImage = map["blockNetworkImage"];
     options.blockNetworkLoads = map["blockNetworkLoads"];
     options.cacheMode = AndroidCacheMode.fromValue(map["cacheMode"]);


### PR DESCRIPTION
…led to reflect compileSdkVersion 33 changes

[WebSettings](https://developer.android.com/reference/android/webkit/WebSettings#setAppCachePath(java.lang.String)) no longer contains setAppCachePath property as of Android 12 (compileSdkVersion 33)

## Connection with issue(s)

Resolve issue #1299

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->

Connected to #1269, #1234, #1223

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->

## Testing and Review Notes

<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->
Just run the example app to see that it builds on compileSdkVersion 33

## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] request the "UX" team perform a design review (if/when applicable)
