### PR TITLE
Disable exporting activity definitions for Android

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,25 +4,25 @@
     <application>
         <activity
             android:theme="@style/AppTheme"
-            android:exported="true"
+            android:exported="false"
             android:name="com.pichillilorenzo.flutter_inappwebview.in_app_browser.InAppBrowserActivity"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density" />
         <activity
             android:theme="@style/ThemeTransparent"
-            android:exported="true"
+            android:exported="false"
             android:name="com.pichillilorenzo.flutter_inappwebview.chrome_custom_tabs.ChromeCustomTabsActivity" />
         <activity
             android:theme="@style/ThemeTransparent"
-            android:exported="true"
+            android:exported="false"
             android:name="com.pichillilorenzo.flutter_inappwebview.chrome_custom_tabs.TrustedWebActivity" />
         <activity
             android:theme="@style/ThemeTransparent"
-            android:exported="true"
+            android:exported="false"
             android:name="com.pichillilorenzo.flutter_inappwebview.chrome_custom_tabs.ChromeCustomTabsActivitySingleInstance"
             android:launchMode="singleInstance"/>
         <activity
             android:theme="@style/ThemeTransparent"
-            android:exported="true"
+            android:exported="false"
             android:name="com.pichillilorenzo.flutter_inappwebview.chrome_custom_tabs.TrustedWebActivitySingleInstance"
             android:launchMode="singleInstance"/>
         <receiver


### PR DESCRIPTION
## Testing and Review Notes

During a recent penetration test of an application that embedded our flutter application (add-to-app) it was mentioned that `flutter_inappwebview` was exporting activity definitions and that these could be reached from other applications. We don't see any reason why these need to be exported.