### PR TITLE
Add directoryIndex and documentRoot to InAppLocalhostServer option

### DIFF
--- a/lib/src/in_app_localhost_server.dart
+++ b/lib/src/in_app_localhost_server.dart
@@ -12,13 +12,16 @@ class InAppLocalhostServer {
   HttpServer? _server;
   int _port = 8080;
   String _directoryIndex = 'index.html';
+  String _documentRoot = './';
 
   InAppLocalhostServer({
     int port = 8080,
     String directoryIndex = 'index.html',
+    String documentRoot = './',
   }) {
     this._port = port;
     this._directoryIndex = directoryIndex;
+    this._documentRoot = (documentRoot.endsWith('/')) ? documentRoot : '$documentRoot/';
   }
 
   ///Starts the server on `http://localhost:[port]/`.
@@ -52,6 +55,7 @@ class InAppLocalhostServer {
           var path = request.requestedUri.path;
           path = (path.startsWith('/')) ? path.substring(1) : path;
           path += (path.endsWith('/')) ? _directoryIndex : '';
+          path = _documentRoot + path;
 
           try {
             body = (await rootBundle.load(path)).buffer.asUint8List();

--- a/lib/src/in_app_localhost_server.dart
+++ b/lib/src/in_app_localhost_server.dart
@@ -11,9 +11,14 @@ class InAppLocalhostServer {
   bool _started = false;
   HttpServer? _server;
   int _port = 8080;
+  String _directoryIndex = 'index.html';
 
-  InAppLocalhostServer({int port = 8080}) {
+  InAppLocalhostServer({
+    int port = 8080,
+    String directoryIndex = 'index.html',
+  }) {
     this._port = port;
+    this._directoryIndex = directoryIndex;
   }
 
   ///Starts the server on `http://localhost:[port]/`.
@@ -46,7 +51,7 @@ class InAppLocalhostServer {
 
           var path = request.requestedUri.path;
           path = (path.startsWith('/')) ? path.substring(1) : path;
-          path += (path.endsWith('/')) ? 'index.html' : '';
+          path += (path.endsWith('/')) ? _directoryIndex : '';
 
           try {
             body = (await rootBundle.load(path)).buffer.asUint8List();


### PR DESCRIPTION
## Connection with issue(s)

## How is the feature useful 

Less hassle when loading existing html for websites.

## Testing and Review Notes

```
final InAppLocalhostServer localhostServer = InAppLocalhostServer(
  port: 8080,
  documentRoot: "./assets/website/",
  directoryIndex: "index.html",
);
```

## Screenshots or Videos

## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable)
