### PR TITLE
fix: type 'Null' is not a subtype of type 'bool'

### DIFF
--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -4595,7 +4595,7 @@ class RendererPriorityPolicy {
         ? RendererPriorityPolicy(
             rendererRequestedPriority:
                 RendererPriority.fromValue(map["rendererRequestedPriority"]),
-            waivedWhenNotVisible: map["waivedWhenNotVisible"])
+            waivedWhenNotVisible: map["waivedWhenNotVisible"] ?? false)
         : null;
   }
 }


### PR DESCRIPTION
E/flutter (10050): [ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: type 'Null' is not a subtype of type 'bool'
E/flutter (10050): #0      RendererPriorityPolicy.fromMap (package:flutter_inappwebview/src/types.dart:4598:38)
E/flutter (10050): #1      AndroidInAppWebViewOptions.fromMap (package:flutter_inappwebview/src/in_app_webview/android/in_app_webview_options.dart:422:61)
E/flutter (10050): #2      InAppWebViewGroupOptions.fromMap (package:flutter_inappwebview/src/in_app_webview/in_app_webview_options.dart:72:38)
E/flutter (10050): #3      InAppWebViewController.getOptions (package:flutter_inappwebview/src/in_app_webview/in_app_webview_controller.dart:1643:39)
E/flutter (10050): <asynchronous suspension>
E/flutter (10050): #4      _WebViewTabState._buildWebView.<anonymous closure> (package:flutter_browser/webview_tab.dart:158:39)
E/flutter (10050): <asynchronous suspension>

## Connection with issue(s)

Resolve issue #???

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->

Connected to #???

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->

## Testing and Review Notes

<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->


## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable)
