### PR TITLE
fix(ios): invoke onBrowserCreated when viewDidLoad is called with win…

### DIFF
--- a/ios/Classes/InAppBrowser/InAppBrowserWebViewController.swift
+++ b/ios/Classes/InAppBrowser/InAppBrowserWebViewController.swift
@@ -116,6 +116,7 @@ public class InAppBrowserWebViewController: UIViewController, InAppBrowserDelega
         
         if let wId = windowId, let webViewTransport = InAppWebView.windowWebViews[wId] {
             webView.load(webViewTransport.request)
+            onBrowserCreated()
         } else {
             if #available(iOS 11.0, *) {
                 if let contentBlockers = webView.options?.contentBlockers, contentBlockers.count > 0 {


### PR DESCRIPTION
When an `InAppBrowser` is created with the past `windowId`, the `onBrowserCreated` method is not called and the `isOpened` flag does not become `true`.
In this case, when you try to call `InAppBrowser.close,` an `InAppBrowserNotOpenedException` is thrown.

Example: 
```dart
import 'package:flutter_inappwebview/flutter_inappwebview.dart';

class CrossSiteBrowser extends InAppBrowser {
  CrossSiteBrowser({
    required int windowId,
    required Uri url,
  }) : super(windowId: windowId) {
    openUrlRequest(urlRequest: URLRequest(url: url));
  }

  @override
  Future onLoadStart(url) async {
    await Future.delayed(const Duration(seconds: 10), close);
  }
}

```