### PR TITLE
Fix #1350, Handling the dart uri parser's problem(cannot parse uri including ':')

### DIFF
--- a/lib/src/in_app_browser/in_app_browser.dart
+++ b/lib/src/in_app_browser/in_app_browser.dart
@@ -519,6 +519,8 @@ class InAppBrowser {
   ///- MacOS
   void onConsoleMessage(ConsoleMessage consoleMessage) {}
 
+  void onShouldOverrideUrlLoadingFailedToParseUri(String url) {}
+
   ///Give the host application a chance to take control when a URL is about to be loaded in the current WebView. This event is not called on the initial load of the WebView.
   ///
   ///Note that on Android there isn't any way to load an URL for a frame that is not the main frame, so if the request is not for the main frame, the navigation is allowed by default.

--- a/lib/src/in_app_webview/headless_in_app_webview.dart
+++ b/lib/src/in_app_webview/headless_in_app_webview.dart
@@ -51,7 +51,11 @@ class HeadlessInAppWebView implements WebView, Disposable {
   ///**NOTE for Android**: `Size` width and height values will be converted to `int` values because they cannot have `double` values.
   final Size initialSize;
 
+  @override
+  void Function(InAppWebViewController controller, String url)? onShouldOverrideUrlLoadingFailedToParseUri;
+
   HeadlessInAppWebView({
+    this.onShouldOverrideUrlLoadingFailedToParseUri,
     this.initialSize = const Size(-1, -1),
     this.windowId,
     this.initialUrlRequest,

--- a/lib/src/in_app_webview/in_app_webview.dart
+++ b/lib/src/in_app_webview/in_app_webview.dart
@@ -55,7 +55,11 @@ class InAppWebView extends StatefulWidget implements WebView {
   ///- Web
   final HeadlessInAppWebView? headlessWebView;
 
+  @override
+  final void Function(InAppWebViewController controller, String url)? onShouldOverrideUrlLoadingFailedToParseUri;
+
   const InAppWebView({
+    this.onShouldOverrideUrlLoadingFailedToParseUri,
     Key? key,
     this.windowId,
     this.initialUrlRequest,

--- a/lib/src/in_app_webview/webview.dart
+++ b/lib/src/in_app_webview/webview.dart
@@ -18,6 +18,7 @@ import '../debug_logging_settings.dart';
 
 ///Abstract class that represents a WebView. Used by [InAppWebView], [HeadlessInAppWebView] and the WebView of [InAppBrowser].
 abstract class WebView {
+  final void Function(InAppWebViewController controller, String url)? onShouldOverrideUrlLoadingFailedToParseUri;
   ///Debug settings used by [InAppWebView], [HeadlessInAppWebView] and [InAppBrowser].
   ///The default value excludes the [WebView.onScrollChanged], [WebView.onOverScrolled] and [WebView.onReceivedIcon] events.
   static DebugLoggingSettings debugLoggingSettings = DebugLoggingSettings(
@@ -1021,7 +1022,8 @@ abstract class WebView {
   final WebViewImplementation implementation;
 
   WebView(
-      {this.windowId,
+      {this.onShouldOverrideUrlLoadingFailedToParseUri,
+      this.windowId,
       this.onWebViewCreated,
       this.onLoadStart,
       this.onLoadStop,


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #1350

## Purpose

Adding onShouldOverrideUrlLoadingFailedToParseUri to handle the dart uri parser's problem(cannot parse uri including ':').
## Example
I made a method channel and passed the original url to native.
kotlin, swift will handle the original url when the exception is raied.

```
InAppWebView(
    onShouldOverrideUrlLoadingFailedToParseUri: (controller, url) async {
      if (Platform.isAndroid) {
        await AndroidMethod.onShouldOverrideUrlLoadingFailedToParseUri(url: url);
        return;
      }
      if (Platform.isIOS) {
        await IosMethod.UIApplicationSharedOpen(url: url);
        return;
      }
    },
    shouldOverrideUrlLoading: (controller, navigationAction) async {
      Uri uri = navigationAction.request.url!;
      
      if (uri.scheme.toLowerCase() == "shouldOverrideUrlLoading") {
        return NavigationActionPolicy.CANCEL;
      }
      ....
    },
)
```