### PR TITLE
fix: xcode 14 iOS 12 crash dyld: Library not loaded: /usr/lib/swift/l…

### DIFF
--- a/ios/flutter_inappwebview.podspec
+++ b/ios/flutter_inappwebview.podspec
@@ -20,6 +20,13 @@ A new Flutter plugin.
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
+
+  s.libraries = 'swiftCoreGraphics'
+
+  s.xcconfig = {
+      'LIBRARY_SEARCH_PATHS' => '$(SDKROOT)/usr/lib/swift',
+  }
+
   s.swift_version = '5.0'
 
   s.dependency 'OrderedSet', '~>5.0'


### PR DESCRIPTION
…ibswiftCoreGraphics.dylib Reason: image not found

## Connection with issue(s)

Resolve issue #1495, #1494
