### PR TITLE
iOS: fix window.open().location.href=...

### DIFF
--- a/ios/Classes/InAppWebView/FlutterWebViewController.swift
+++ b/ios/Classes/InAppWebView/FlutterWebViewController.swift
@@ -139,7 +139,10 @@ public class FlutterWebViewController: NSObject, FlutterPlatformView, Disposable
             load(initialUrlRequest: initialUrlRequest, initialFile: initialFile, initialData: initialData)
         }
         else if let wId = windowId, let webViewTransport = webView.plugin?.inAppWebViewManager?.windowWebViews[wId] {
-            webView.load(webViewTransport.request)
+            // only load request if it's not a blank request.
+            if webViewTransport.request.url?.absoluteString != "" {
+                webView.load(webViewTransport.request)
+            }
         }
     }
     


### PR DESCRIPTION
## Connection with issue(s)

(Maybe?) Resolves issue #1500

When implementing a `InAppWebView` with `javaScriptCanOpenWindowsAutomatically: true` and implementing `onCreateWindow` to create multiple windows the following javascript code did not work as expected:

```javascript
var w = window.open("","_blank");
w.location.href="https://www.google.com/";
```

this would open a new window with "about:blank" and the given URL is never loaded **on iOS** (works on android).

## Testing and Review Notes

<details>
<summary>simple open a page with the above javascript code.. </summary>

```
<a href="test.html" onclick="testit();return false;">test open window</a>
<script>
function testit() {
var w = window.open("","_blank");
w.location.href="https://www.google.com/";
}
</script>
```

</details>
