### PR TITLE
Fix: Wait for a blank page to be loaded before closing the browser

### DIFF
--- a/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/in_app_browser/InAppBrowserActivity.java
+++ b/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/in_app_browser/InAppBrowserActivity.java
@@ -548,10 +548,10 @@ public class InAppBrowserActivity extends AppCompatActivity implements InAppBrow
           webView.destroy();
           webView = null;
           manager = null;
+          finish();
         }
       });
       webView.loadUrl("about:blank");
-      finish();
     }
   }
 


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #1658 

## Testing and Review Notes

1. Open the website with the exit confirmation in the in-app browser on Android.
2. Try to close the in-app browser.
3. Observe the confirmation dialog.
4. Hit `Stay on this page`.
5. You should stay on the current page.
6. Try to close the in-app browser again.
8. Press `Leave this page` on the confirmation dialog.
9. The in-app browser should close.
10. Try to open this website again.
11. The page should be loaded again.

## Screenshots or Videos

Before this fix:
https://github.com/pichillilorenzo/flutter_inappwebview/assets/98315622/a3acb3d6-5b16-4bb5-98e2-705c68ad87b2


After this fix: 
https://github.com/pichillilorenzo/flutter_inappwebview/assets/98315622/115aa589-57d6-4417-8134-fc73440a66e8


## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable)
