### PR TITLE
Fix iOS and macOS Forced unwrap null value HTTPCookie for CookieManager.setCookie

### DIFF
--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="InAppWebViewTheme" parent="Theme.AppCompat">
-        <item name="colorAccent">@color/black</item>
+        <item name="colorAccent">@android:color/black</item>
     </style>
 
     <style name="AppTheme" parent="Theme.AppCompat.Light">
-        <item name="colorAccent">@color/black</item>
+        <item name="colorAccent">@android:color/black</item>
     </style>
 
     <style name="ThemeTransparent" parent="android:Theme">
@@ -15,6 +15,6 @@
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowIsFloating">true</item>
         <item name="android:backgroundDimEnabled">false</item>
-        <item name="colorAccent">@color/black</item>
+        <item name="colorAccent">@android:color/black</item>
     </style>
 </resources>

--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="InAppWebViewTheme" parent="Theme.AppCompat">
-        <item name="colorAccent">@android:color/black</item>
+
     </style>
 
     <style name="AppTheme" parent="Theme.AppCompat.Light">
-        <item name="colorAccent">@android:color/black</item>
+
     </style>
 
     <style name="ThemeTransparent" parent="android:Theme">
@@ -15,6 +15,5 @@
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowIsFloating">true</item>
         <item name="android:backgroundDimEnabled">false</item>
-        <item name="colorAccent">@android:color/black</item>
     </style>
 </resources>

--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="InAppWebViewTheme" parent="Theme.AppCompat">
-
+        <item name="colorAccent">@color/black</item>
     </style>
 
     <style name="AppTheme" parent="Theme.AppCompat.Light">
-
+        <item name="colorAccent">@color/black</item>
     </style>
 
     <style name="ThemeTransparent" parent="android:Theme">
@@ -15,5 +15,6 @@
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowIsFloating">true</item>
         <item name="android:backgroundDimEnabled">false</item>
+        <item name="colorAccent">@color/black</item>
     </style>
 </resources>

--- a/ios/Classes/MyCookieManager.swift
+++ b/ios/Classes/MyCookieManager.swift
@@ -136,6 +136,8 @@ public class MyCookieManager: ChannelDelegate {
             MyCookieManager.httpCookieStore.setCookie(cookie, completionHandler: {() in
                 result(true)
             })
+        } else {
+            result(false)
         }
     }
     

--- a/ios/Classes/MyCookieManager.swift
+++ b/ios/Classes/MyCookieManager.swift
@@ -133,15 +133,10 @@ public class MyCookieManager: ChannelDelegate {
         
         
         if let cookie = HTTPCookie(properties: properties) {
-          httpCookieStore.setCookie(cookie, completionHandler: {() in
-             result(true)
-          })
+            MyCookieManager.httpCookieStore.setCookie(cookie, completionHandler: {() in
+                result(true)
+            })
         }
-        let cookie = HTTPCookie(properties: properties)!
-        
-        MyCookieManager.httpCookieStore.setCookie(cookie, completionHandler: {() in
-            result(true)
-        })
     }
     
     public static func getCookies(url: String, result: @escaping FlutterResult) {

--- a/ios/Classes/MyCookieManager.swift
+++ b/ios/Classes/MyCookieManager.swift
@@ -131,6 +131,12 @@ public class MyCookieManager: ChannelDelegate {
             }
         }
         
+        
+        if let cookie = HTTPCookie(properties: properties) {
+          httpCookieStore.setCookie(cookie, completionHandler: {() in
+             result(true)
+          })
+        }
         let cookie = HTTPCookie(properties: properties)!
         
         MyCookieManager.httpCookieStore.setCookie(cookie, completionHandler: {() in


### PR DESCRIPTION
## Connection with issue(s)

No issue created

## Testing and Review Notes

[v6.0.0-beta.23](https://github.com/pichillilorenzo/flutter_inappwebview/releases/tag/v6.0.0-beta.23) an error is thrown here:

let cookie = HTTPCookie(properties: properties)!

A force unwrap is done on a value that can be null. The PR wraps a null check around it.

<img width="1215" alt="Bildschirmfoto 2023-05-31 um 11 19 09" src="https://github.com/pichillilorenzo/flutter_inappwebview/assets/72440045/8698ce79-8dfa-4b88-a4f3-4df7de4a997d">

