### PR TITLE
fix cert parsing for ios 12

### DIFF
--- a/ios/Classes/Types/SecCertificate.swift
+++ b/ios/Classes/Types/SecCertificate.swift
@@ -10,9 +10,6 @@ import Foundation
 extension SecCertificate {
     var data: Data {
         let serverCertificateCFData = SecCertificateCopyData(self)
-        let data = CFDataGetBytePtr(serverCertificateCFData)
-        let size = CFDataGetLength(serverCertificateCFData)
-        let certificateData = NSData(bytes: data, length: size)
-        return Data(certificateData)
+        return serverCertificateCFData as Data
     }
 }

--- a/macos/Classes/Types/SecCertificate.swift
+++ b/macos/Classes/Types/SecCertificate.swift
@@ -10,9 +10,6 @@ import Foundation
 extension SecCertificate {
     var data: Data {
         let serverCertificateCFData = SecCertificateCopyData(self)
-        let data = CFDataGetBytePtr(serverCertificateCFData)
-        let size = CFDataGetLength(serverCertificateCFData)
-        let certificateData = NSData(bytes: data, length: size)
-        return Data(certificateData)
+        return serverCertificateCFData as Data
     }
 }


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #524 

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->

Connected to #631 

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->

## Testing and Review Notes

<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->
Build and run in iOS 12 with HTTPS site, expected to stop triggering `ASN1ParseError` and properly retrieve value from `getCertificate`.

## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
