### PR TITLE
android imm.isAcceptingText() crash fix

### DIFF
--- a/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/webview/in_app_webview/InAppWebView.java
+++ b/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/webview/in_app_webview/InAppWebView.java
@@ -1525,7 +1525,14 @@ final public class InAppWebView extends InputAwareWebView implements InAppWebVie
                         public void run() {
                           InputMethodManager imm =
                                   (InputMethodManager) getContext().getSystemService(INPUT_METHOD_SERVICE);
-                          if (containerView != null && imm != null && !imm.isAcceptingText()) {
+                          boolean isAcceptingText = false;
+                          try {
+                            if (imm != null) {
+                              isAcceptingText = imm.isAcceptingText();
+                            }
+                          } catch (Exception ignored) {
+                          }
+                          if (containerView != null && imm != null && !isAcceptingText) {
                             imm.hideSoftInputFromWindow(
                                     containerView.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
                           }

--- a/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/webview/in_app_webview/InAppWebView.java
+++ b/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/webview/in_app_webview/InAppWebView.java
@@ -1528,6 +1528,7 @@ final public class InAppWebView extends InputAwareWebView implements InAppWebVie
                           boolean isAcceptingText = false;
                           try {
                             if (imm != null) {
+                              // imm.isAcceptingText() seems to sometimes crash on some devices
                               isAcceptingText = imm.isAcceptingText();
                             }
                           } catch (Exception ignored) {

--- a/lib/src/in_app_webview/in_app_webview_controller.dart
+++ b/lib/src/in_app_webview/in_app_webview_controller.dart
@@ -1878,7 +1878,7 @@ class InAppWebViewController {
   ///- MacOS ([Official API - WKWebView.canGoBack](https://developer.apple.com/documentation/webkit/wkwebview/1414966-cangoback))
   Future<bool> canGoBack() async {
     Map<String, dynamic> args = <String, dynamic>{};
-    return await _channel?.invokeMethod('canGoBack', args);
+    return await _channel?.invokeMethod<bool>('canGoBack', args) ?? false;
   }
 
   ///Goes forward in the history of the WebView.

--- a/lib/src/in_app_webview/in_app_webview_controller.dart
+++ b/lib/src/in_app_webview/in_app_webview_controller.dart
@@ -1903,7 +1903,7 @@ class InAppWebViewController {
   ///- MacOS ([Official API - WKWebView.canGoForward](https://developer.apple.com/documentation/webkit/wkwebview/1414962-cangoforward))
   Future<bool> canGoForward() async {
     Map<String, dynamic> args = <String, dynamic>{};
-    return await _channel?.invokeMethod('canGoForward', args);
+    return await _channel?.invokeMethod('canGoForward', args) ?? false;
   }
 
   ///Goes to the history item that is the number of steps away from the current item. Steps is negative if backward and positive if forward.


### PR DESCRIPTION
I see some isolated cases where `isAcceptingText` crashes, killing the entire app. Added a small safety net to avoid this.

P.s. This was fully reproducible for one user (Huawei P30 light - Android 10) when accessing app.dexhunter.io. 

<img width="1139" alt="image" src="https://github.com/pichillilorenzo/flutter_inappwebview/assets/38853913/45b74c53-665e-4d01-8e5d-9996ce7734f6">