### PR TITLE
Adds NavigationActionPolicy to allow without try open app link

### DIFF
--- a/lib/src/types/navigation_action_policy.dart
+++ b/lib/src/types/navigation_action_policy.dart
@@ -22,4 +22,8 @@ class NavigationActionPolicy_ {
   ///
   ///**NOTE**: available only on iOS 14.5+. It will fallback to [CANCEL].
   static const DOWNLOAD = const NavigationActionPolicy_._internal(2);
+
+  ///Allow the navigation to continue without trying app link.
+  static const ALLOW_WITHOUT_TRYING_APP_LINK =
+      NavigationActionPolicy_._internal(3);
 }

--- a/lib/src/types/navigation_action_policy.g.dart
+++ b/lib/src/types/navigation_action_policy.g.dart
@@ -28,11 +28,16 @@ class NavigationActionPolicy {
   ///**NOTE**: available only on iOS 14.5+. It will fallback to [CANCEL].
   static const DOWNLOAD = NavigationActionPolicy._internal(2, 2);
 
+  ///Allow the navigation to continue without trying app link.
+  static const ALLOW_WITHOUT_TRYING_APP_LINK =
+      NavigationActionPolicy._internal(3, 3);
+
   ///Set of all values of [NavigationActionPolicy].
   static final Set<NavigationActionPolicy> values = [
     NavigationActionPolicy.ALLOW,
     NavigationActionPolicy.CANCEL,
     NavigationActionPolicy.DOWNLOAD,
+    NavigationActionPolicy.ALLOW_WITHOUT_TRYING_APP_LINK,
   ].toSet();
 
   ///Gets a possible [NavigationActionPolicy] instance from [int] value.
@@ -82,6 +87,8 @@ class NavigationActionPolicy {
         return 'CANCEL';
       case 2:
         return 'DOWNLOAD';
+      case 3:
+        return 'ALLOW_WITHOUT_TRYING_APP_LINK';
     }
     return _value.toString();
   }


### PR DESCRIPTION
## Connection with issue(s)

We need keep the website navigation in our webview when exist [Universal Links](https://developer.apple.com/library/archive/documentation/General/Conceptual/AppSearch/UniversalLinks.html).
searching a little on the internet i find some discursions about solve it like [this](https://stackoverflow.com/questions/38450586/prevent-universal-links-from-opening-in-wkwebview-uiwebview). And there is a const to do it, its `3`. You can see that in the original [webkit code source](https://opensource.apple.com/source/WebKit2/WebKit2-7608.5.11/UIProcess/API/Cocoa/WKNavigationDelegatePrivate.h):

`static const WKNavigationActionPolicy WK_API_AVAILABLE(macos(10.11), ios(9.0)) _WKNavigationActionPolicyAllowWithoutTryingAppLink = (WKNavigationActionPolicy)(_WKNavigationActionPolicyDownload + 1);
`

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->

## Testing and Review Notes

<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->


## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] request the "UX" team perform a design review (if/when applicable)
