### PR TITLE
Resolve applying user scripts on Android on sites where trusted-types CSP is activated. 

### DIFF
--- a/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/types/UserContentController.java
+++ b/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/types/UserContentController.java
@@ -419,20 +419,33 @@ public class UserContentController implements Disposable {
           "    if (document.body == null) {return;}" +
           "    var contentWorldNames = [" + PluginScriptsUtil.VAR_CONTENT_WORLD_NAME_ARRAY + "];" +
           "    for (var contentWorldName of contentWorldNames) {" +
-          "      var iframeId = '" + JavaScriptBridgeJS.JAVASCRIPT_BRIDGE_NAME + "_' + contentWorldName;" +
-          "      var iframe = document.getElementById(iframeId);" +
-          "      if (iframe == null) {" +
-          "        iframe = document.createElement('iframe');" +
-          "        iframe.id = iframeId;" +
-          "        iframe.style = 'display: none; z-index: 0; position: absolute; width: 0px; height: 0px';" +
-          "        document.body.append(iframe);" +
-          "      }" +
-          "      if (iframe.contentWindow.document.getElementById('" + JavaScriptBridgeJS.JAVASCRIPT_BRIDGE_NAME + "_plugin_scripts') == null) {" +
-          "        var script = iframe.contentWindow.document.createElement('script');" +
-          "        script.id = '" + JavaScriptBridgeJS.JAVASCRIPT_BRIDGE_NAME + "_plugin_scripts';" +
-          "        script.innerHTML = " + PluginScriptsUtil.VAR_JSON_SOURCE_ENCODED + ";" +
-          "        iframe.contentWindow.document.body.append(script);" +
-          "      }" +
+          "       try {" +
+          "         var iframeId = '" + JavaScriptBridgeJS.JAVASCRIPT_BRIDGE_NAME + "_' + contentWorldName;" +
+          "         var iframe = document.getElementById(iframeId);" +
+          "         if (iframe == null) {" +
+          "           iframe = document.createElement('iframe');" +
+          "           iframe.id = iframeId;" +
+          "           iframe.style = 'display: none; z-index: 0; position: absolute; width: 0px; height: 0px';" +
+          "           document.body.append(iframe);" +
+          "         }" +
+          "         if (iframe.contentWindow.document.getElementById('" + JavaScriptBridgeJS.JAVASCRIPT_BRIDGE_NAME + "_plugin_scripts') == null) {" +
+          "           var script; debugger;" +
+          "           var innerHTML = " + PluginScriptsUtil.VAR_JSON_SOURCE_ENCODED + ";" +
+          "           if (window.trustedTypes && window.trustedTypes.createPolicy) {" +
+          "             policy = window.trustedTypes.createPolicy('flutter_inappwebview', {" +
+          "               createHTML: function(string) { return string; }," +
+          "               createScript: function(string) { return string; }," +
+          "             });" +
+          "             var innerHTML = policy.createHTML(innerHTML);" +
+          "             script = policy.createScript(innerHTML);" +
+          "           } else {" +
+          "             script = iframe.contentWindow.document.createElement('script');" +
+          "             script.innerHTML = innerHTML;" +
+          "           }" +
+          "           script.id = '" + JavaScriptBridgeJS.JAVASCRIPT_BRIDGE_NAME + "_plugin_scripts';" +
+          "           iframe.contentWindow.document.body.append(script);" +
+          "         }" +
+          "       } catch(e) { console.error(e); }" +
           "    }" +
           "    clearInterval(interval);" +
           "  });" +

--- a/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/types/UserContentController.java
+++ b/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/types/UserContentController.java
@@ -429,7 +429,7 @@ public class UserContentController implements Disposable {
           "           document.body.append(iframe);" +
           "         }" +
           "         if (iframe.contentWindow.document.getElementById('" + JavaScriptBridgeJS.JAVASCRIPT_BRIDGE_NAME + "_plugin_scripts') == null) {" +
-          "           var script; debugger;" +
+          "           var script;" +
           "           var innerHTML = " + PluginScriptsUtil.VAR_JSON_SOURCE_ENCODED + ";" +
           "           if (window.trustedTypes && window.trustedTypes.createPolicy) {" +
           "             policy = window.trustedTypes.createPolicy('flutter_inappwebview', {" +


### PR DESCRIPTION
## Connection with issue(s)

Resolve applying user scripts on Android on sites where trusted-types CSP is activated. 

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->

## Testing and Review Notes

<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->
Try to login to gmail and you'll see `Content-Security-Policy-Report-Only: require-trusted-types-for 'script'; report-uri https://csp.withgoogle.com/csp/boq-infra/googlegrowth-boq-js-css-signers` header on  https://gds.google.com

## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable)
