### PR TITLE
💥 Fix crash - remove force unwrapping from dispose method

### DIFF
--- a/flutter_inappwebview_ios/ios/Classes/InAppBrowser/InAppBrowserWebViewController.swift
+++ b/flutter_inappwebview_ios/ios/Classes/InAppBrowser/InAppBrowserWebViewController.swift
@@ -633,16 +633,16 @@ public class InAppBrowserWebViewController: UIViewController, InAppBrowserDelega
         webView?.removeFromSuperview()
         webView = nil
         view = nil
-        if previousStatusBarStyle != -1 {
-            UIApplication.shared.statusBarStyle = UIStatusBarStyle(rawValue: previousStatusBarStyle)!
+        if previousStatusBarStyle != -1, let statusBarStyle = UIStatusBarStyle(rawValue: previousStatusBarStyle) {
+            UIApplication.shared.statusBarStyle = statusBarStyle
         }
         transitioningDelegate = nil
-        searchBar.delegate = nil
-        closeButton.target = nil
-        forwardButton.target = nil
-        backButton.target = nil
-        reloadButton.target = nil
-        shareButton.target = nil
+        searchBar?.delegate = nil
+        closeButton?.target = nil
+        forwardButton?.target = nil
+        backButton?.target = nil
+        reloadButton?.target = nil
+        shareButton?.target = nil
         menuButton?.target = nil
         plugin = nil
     }


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue https://github.com/pichillilorenzo/flutter_inappwebview/issues/1931

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->

Connected to https://github.com/pichillilorenzo/flutter_inappwebview/issues/1931

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->

## Testing and Review Notes


<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->


## Screenshots or Videos

The properties are explicitly unwrapped optionals. And if one of them happens to be `nil` for whatever reason, the app would crash. This prevents it.

![Screenshot 2023-12-20 at 11 30 59](https://github.com/pichillilorenzo/flutter_inappwebview/assets/35694712/a79cb29a-279f-4cd8-81ae-2676666ee5ac)
