### PR TITLE
💥 Fix iPad crash due to missing `sourceView`

### DIFF
--- a/flutter_inappwebview_ios/ios/Classes/InAppBrowser/InAppBrowserManager.swift
+++ b/flutter_inappwebview_ios/ios/Classes/InAppBrowser/InAppBrowserManager.swift
@@ -114,7 +114,15 @@ public class InAppBrowserManager: ChannelDelegate {
             assertionFailure("Failure init the visibleViewController!")
             return
         }
-        
+
+        if let popover = navController.popoverPresentationController {
+            let sourceView = visibleViewController.view ?? UIView()
+
+            popover.sourceRect = CGRect(x: sourceView.bounds.midX, y: sourceView.bounds.midY, width: 0, height: 0)
+            popover.permittedArrowDirections = []
+            popover.sourceView = sourceView
+        }
+
         visibleViewController.present(navController, animated: animated)
     }
     


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue https://github.com/pichillilorenzo/flutter_inappwebview/issues/1928

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->

Connected to https://github.com/pichillilorenzo/flutter_inappwebview/issues/1928

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->

## Testing and Review Notes

The `sourceView` was missing. It might also be missing in other places, but I haven't yet got time to check - can be done in future PRs.

Also, the look is not ideal, as it's really narrow - but that's for another PR. The main thing is that this scenario does not cause crashes anymore 🎉 .

## Screenshots or Videos
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-12-20 at 12 11 29](https://github.com/pichillilorenzo/flutter_inappwebview/assets/35694712/ec0cf832-300f-47d6-bc4b-aba32f6fbc1b)

