### PR TITLE
issue #1983: Fixed to prevent Activity from being restored

### DIFF
--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/in_app_browser/InAppBrowserActivity.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/in_app_browser/InAppBrowserActivity.java
@@ -82,6 +82,11 @@ public class InAppBrowserActivity extends AppCompatActivity implements InAppBrow
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
 
+    if (savedInstanceState != null) {
+      finish();
+      return;
+    }
+
     Bundle b = getIntent().getExtras();
     if (b == null) return;
     


### PR DESCRIPTION
@pichillilorenzo 

## Connection with issue(s)

Resolve issue #1983

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->

Connected to #1983 

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->

## Testing and Review Notes

<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->

1. launch the example application and open InAPpBrowser
2. kill the process depending on the OS (can be achieved by changing permissions)
3. start the example app again MainActivity is restarted and operation is possible (InAppBrowser is closed)

## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

After this PR marged: 
![output2](https://github.com/pichillilorenzo/flutter_inappwebview/assets/118415919/72c20032-ec7e-4253-88a8-c5a56fd9d82c)

## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor 

ready for review -->
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable)


Best Regards,