### PR TITLE
Add privacy manifest for iOS

### DIFF
--- a/flutter_inappwebview_ios/ios/Resources/PrivacyInfo.xcprivacy
+++ b/flutter_inappwebview_ios/ios/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/flutter_inappwebview_ios/ios/flutter_inappwebview_ios.podspec
+++ b/flutter_inappwebview_ios/ios/flutter_inappwebview_ios.podspec
@@ -17,6 +17,7 @@ A new Flutter plugin.
   s.resources = 'Storyboards/**/*.storyboard'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
+  s.resource_bundles = {'flutter_inappwebview_ios_privacy' => ['Resources/PrivacyInfo.xcprivacy']}
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #1909

This adds an empty privacy manifest. I could not find this library using any of the listed methods from https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api

This is similar to the changes seen in the first party Flutter plugins https://github.com/pichillilorenzo/flutter_inappwebview/issues/1909

## Testing and Review Notes

I'm not really sure how to test this. I guess if this builds it's fine?