### PR TITLE
Consider that browsers might not be supported by devices

### DIFF
--- a/flutter_inappwebview/example/integration_test/util.dart
+++ b/flutter_inappwebview/example/integration_test/util.dart
@@ -170,6 +170,9 @@ class MyChromeSafariBrowser extends ChromeSafariBrowser {
   }
 
   @override
+  void onBrowserNotSupported() {}
+
+  @override
   void onClosed() {
     closed.complete();
   }

--- a/flutter_inappwebview/example/lib/chrome_safari_browser_example.screen.dart
+++ b/flutter_inappwebview/example/lib/chrome_safari_browser_example.screen.dart
@@ -20,6 +20,11 @@ class MyChromeSafariBrowser extends ChromeSafariBrowser {
   void onClosed() {
     print("ChromeSafari browser closed");
   }
+
+  @override
+  void onBrowserNotSupported() {
+    print("ChromeSafari is not supported");
+  }
 }
 
 class ChromeSafariBrowserExampleScreen extends StatefulWidget {

--- a/flutter_inappwebview/lib/src/chrome_safari_browser/chrome_safari_browser.dart
+++ b/flutter_inappwebview/lib/src/chrome_safari_browser/chrome_safari_browser.dart
@@ -192,4 +192,7 @@ class ChromeSafariBrowser implements PlatformChromeSafariBrowserEvents {
 
   @override
   void onWillOpenInBrowser() {}
+
+  @override
+  void onBrowserNotSupported() {}
 }

--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/chrome_custom_tabs/ChromeCustomTabsActivity.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/chrome_custom_tabs/ChromeCustomTabsActivity.java
@@ -114,9 +114,16 @@ public class ChromeCustomTabsActivity extends Activity implements Disposable {
     customTabActivityHelper.setConnectionCallback(new CustomTabActivityHelper.ConnectionCallback() {
       @Override
       public void onCustomTabsConnected() {
-        customTabsConnected();
-        if (channelDelegate != null) {
-          channelDelegate.onServiceConnected();
+        try {
+          customTabsConnected();
+          if (channelDelegate != null) {
+            channelDelegate.onServiceConnected();
+          }
+        } catch (java.lang.Exception e) {
+          if (channelDelegate != null) {
+            channelDelegate.onBrowserNotSupported();
+          }
+          Log.d(LOG_TAG, "Custom Tabs not supported", e);
         }
       }
 
@@ -181,7 +188,7 @@ public class ChromeCustomTabsActivity extends Activity implements Disposable {
   public void launchUrl(@NonNull String url,
                         @Nullable Map<String, String> headers,
                         @Nullable String referrer,
-                        @Nullable List<String> otherLikelyURLs) {
+                        @Nullable List<String> otherLikelyURLs) throws ClassNotFoundException {
     launchUrlWithSession(customTabsSession, url, headers, referrer, otherLikelyURLs);
   }
 
@@ -189,7 +196,7 @@ public class ChromeCustomTabsActivity extends Activity implements Disposable {
                                    @NonNull String url,
                                    @Nullable Map<String, String> headers,
                                    @Nullable String referrer,
-                                   @Nullable List<String> otherLikelyURLs) {
+                                   @Nullable List<String> otherLikelyURLs) throws ClassNotFoundException {
     mayLaunchUrl(url, otherLikelyURLs);
     builder = new CustomTabsIntent.Builder(session);
     prepareCustomTabs();

--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/chrome_custom_tabs/ChromeCustomTabsChannelDelegate.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/chrome_custom_tabs/ChromeCustomTabsChannelDelegate.java
@@ -243,6 +243,13 @@ public class ChromeCustomTabsChannelDelegate extends ChannelDelegateImpl {
     channel.invokeMethod("onSessionEnded", obj);
   }
 
+  public void onBrowserNotSupported() {
+    MethodChannel channel = getChannel();
+    if (channel == null) return;
+    Map<String, Object> obj = new HashMap<>();
+    channel.invokeMethod("onBrowserNotSupported", obj);
+  }
+
   @Override
   public void dispose() {
     super.dispose();

--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/chrome_custom_tabs/ChromeSafariBrowserManager.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/chrome_custom_tabs/ChromeSafariBrowserManager.java
@@ -55,7 +55,11 @@ public class ChromeSafariBrowserManager extends ChannelDelegateImpl {
           HashMap<String, Object> actionButton = (HashMap<String, Object>) call.argument("actionButton");
           HashMap<String, Object> secondaryToolbar = (HashMap<String, Object>) call.argument("secondaryToolbar");
           List<HashMap<String, Object>> menuItemList = (List<HashMap<String, Object>>) call.argument("menuItemList");
-          open(plugin.activity, viewId, url, headers, referrer, otherLikelyURLs, settings, actionButton, secondaryToolbar, menuItemList, result);
+          try {
+            open(plugin.activity, viewId, url, headers, referrer, otherLikelyURLs, settings, actionButton, secondaryToolbar, menuItemList, result);
+          } catch (ClassNotFoundException e) {
+            result.error(LOG_TAG, e.getMessage(), null);
+          }
         } else {
           result.success(false);
         }

--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/chrome_custom_tabs/CustomTabActivityHelper.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/chrome_custom_tabs/CustomTabActivityHelper.java
@@ -39,7 +39,7 @@ public class CustomTabActivityHelper implements ServiceConnectionCallback {
                                      Uri uri,
                                      @Nullable Map<String, String> headers,
                                      @Nullable Uri referrer,
-                                     int requestCode) {
+                                     int requestCode) throws ClassNotFoundException {
         intent.setData(uri);
         if (headers != null) {
             Bundle bundleHeaders = new Bundle();

--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/in_app_browser/InAppBrowserActivity.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/in_app_browser/InAppBrowserActivity.java
@@ -45,6 +45,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import io.flutter.plugin.common.MethodChannel;
 
@@ -145,7 +146,11 @@ public class InAppBrowserActivity extends AppCompatActivity implements InAppBrow
 
     actionBar = getSupportActionBar();
 
-    prepareView();
+    try {
+      prepareView();
+    } catch (ClassNotFoundException e) {
+      Log.d(LOG_TAG, Objects.requireNonNull(e.getMessage()));
+    }
 
     if (windowId != -1) {
       if (webView.plugin != null && webView.plugin.inAppWebViewManager != null) {
@@ -187,7 +192,7 @@ public class InAppBrowserActivity extends AppCompatActivity implements InAppBrow
     }
   }
 
-  private void prepareView() {
+  private void prepareView() throws ClassNotFoundException {
 
     if (webView != null) {
       webView.prepare();
@@ -421,7 +426,7 @@ public class InAppBrowserActivity extends AppCompatActivity implements InAppBrow
     }
   }
 
-  public void show() {
+  public void show() throws ClassNotFoundException {
     isHidden = false;
     Intent openActivity = new Intent(this, InAppBrowserActivity.class);
     openActivity.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
@@ -451,7 +456,7 @@ public class InAppBrowserActivity extends AppCompatActivity implements InAppBrow
     close(null);
   }
 
-  public void setSettings(InAppBrowserSettings newSettings, HashMap<String, Object> newSettingsMap) {
+  public void setSettings(InAppBrowserSettings newSettings, HashMap<String, Object> newSettingsMap) throws ClassNotFoundException {
 
     InAppWebViewSettings newInAppWebViewSettings = new InAppWebViewSettings();
     newInAppWebViewSettings.parse(newSettingsMap);

--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/WebViewChannelDelegate.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/WebViewChannelDelegate.java
@@ -219,7 +219,11 @@ public class WebViewChannelDelegate extends ChannelDelegateImpl {
           InAppBrowserSettings inAppBrowserSettings = new InAppBrowserSettings();
           HashMap<String, Object> inAppBrowserSettingsMap = (HashMap<String, Object>) call.argument("settings");
           inAppBrowserSettings.parse(inAppBrowserSettingsMap);
-          inAppBrowserActivity.setSettings(inAppBrowserSettings, inAppBrowserSettingsMap);
+          try {
+            inAppBrowserActivity.setSettings(inAppBrowserSettings, inAppBrowserSettingsMap);
+          } catch (ClassNotFoundException e) {
+            result.error(LOG_TAG, e.getMessage(), null);
+          }
         } else if (webView != null) {
           InAppWebViewSettings inAppWebViewSettings = new InAppWebViewSettings();
           HashMap<String, Object> inAppWebViewSettingsMap = (HashMap<String, Object>) call.argument("settings");
@@ -247,7 +251,11 @@ public class WebViewChannelDelegate extends ChannelDelegateImpl {
       case show:
         if (webView != null && webView.getInAppBrowserDelegate() instanceof InAppBrowserActivity) {
           InAppBrowserActivity inAppBrowserActivity = (InAppBrowserActivity) webView.getInAppBrowserDelegate();
-          inAppBrowserActivity.show();
+          try {
+            inAppBrowserActivity.show();
+          } catch (ClassNotFoundException e) {
+            result.error(LOG_TAG, e.getMessage(), null);
+          }
           result.success(true);
         } else {
           result.notImplemented();

--- a/flutter_inappwebview_android/lib/src/chrome_safari_browser/chrome_safari_browser.dart
+++ b/flutter_inappwebview_android/lib/src/chrome_safari_browser/chrome_safari_browser.dart
@@ -173,6 +173,9 @@ class AndroidChromeSafariBrowser extends PlatformChromeSafariBrowser
         final bool didUserInteract = call.arguments["didUserInteract"];
         eventHandler?.onSessionEnded(didUserInteract);
         break;
+      case "onBrowserNotSupported":
+        eventHandler?.onBrowserNotSupported();
+        break;
       default:
         throw UnimplementedError("Unimplemented ${call.method} method");
     }

--- a/flutter_inappwebview_platform_interface/lib/src/chrome_safari_browser/platform_chrome_safari_browser.dart
+++ b/flutter_inappwebview_platform_interface/lib/src/chrome_safari_browser/platform_chrome_safari_browser.dart
@@ -590,6 +590,14 @@ abstract class PlatformChromeSafariBrowserEvents {
   ///{@endtemplate}
   void onGreatestScrollPercentageIncreased(int scrollPercentage) {}
 
+  ///{@template flutter_inappwebview_platform_interface.PlatformChromeSafariBrowser.onBrowserNotSupported}
+  /// Called when the browser is not supported.
+  /// This can happen if a user forces a certain browser package to be used but the browser is not installed on the user's system.
+  void onBrowserNotSupported() {
+    throw UnimplementedError(
+        'onBrowserNotSupported is not implemented on the current platform');
+  }
+
   ///{@template flutter_inappwebview_platform_interface.PlatformChromeSafariBrowser.onSessionEnded}
   ///Called when a `CustomTabsSession` is ending or when no further Engagement Signals
   ///callbacks are expected to report whether any user action has occurred during the session.


### PR DESCRIPTION
## Try catch ClassNotFoundException exceptions when opening activity for intent

Resolve issue #2055

## Testing and Review Notes

The problem it solves is a crash on devices without Chrome when explicitly calling the ChromeSafari with the chrome package on Android. I would like to be able to show the users at least a dialog that the browser they are using is not supported and that they should make sure to install Chrome.

Consider this as draft as I was not able to test it.
The project relies on old dependencies (flutter_inappwebview_platform_interface 1.0.10 instead of 1.0.11) so this is untested and also not clear if I miss places that need to be considered. 
