### PR TITLE
Update proguard-rules.pro

### DIFF
--- a/flutter_inappwebview_android/android/proguard-rules.pro
+++ b/flutter_inappwebview_android/android/proguard-rules.pro
@@ -15,3 +15,4 @@
      private *;
 }
 -keep class com.pichillilorenzo.flutter_inappwebview_android.** { *; }
+-dontwarn android.window.BackEvent


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue: 

```
ERROR: Missing classes detected while running R8. Please add the missing classes or apply additional keep rules that are generated in /Users/manishpatel/Documents/gen3/iv-pro-mobile/build/flutter_inappwebview_android/outputs/mapping/release/missing_rules.txt.
ERROR: R8: Missing class android.window.BackEvent (referenced from: void io.flutter.embedding.android.FlutterActivity.startBackGesture(android.window.BackEvent) and 3 other contexts)
```

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->

Connected to:
```
The latest master channel in flutter gives the above error.
```

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->

## Testing and Review Notes

<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->


## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable)
