### PR TITLE
docs(pubdev): add Android, iOS and Web platforms in pubspec.yaml

### DIFF
--- a/flutter_inappwebview/pubspec.yaml
+++ b/flutter_inappwebview/pubspec.yaml
@@ -10,6 +10,10 @@ topics:
   - webview-flutter
   - inappwebview
   - browser
+platforms:
+  android:
+  ios:
+  web:
 
 environment:
   sdk: ">=2.17.0 <4.0.0"


### PR DESCRIPTION
It seems that this plugin is not supported yet on Desktop and macOS:
- #2004
- #460

On [pub.dev](https://pub.dev/) it is marked as supported for macOS

![image](https://github.com/pichillilorenzo/flutter_inappwebview/assets/73608287/769eccea-a7a6-4921-9d12-691b945bb493)

If you try to use it on macOS platform you will get this exception:

```console
createPlatformInAppWebViewWidget is not implemented on the current platform.
```

This PR explicitly set the supported platforms to update this on the next release in pub.dev page
