### PR TITLE
Fixes SUPPRESS_ERROR_PAGE warning after webview_flutter_android upgrade

### DIFF
--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/in_app_webview/InAppWebView.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/in_app_webview/InAppWebView.java
@@ -431,9 +431,6 @@ final public class InAppWebView extends InputAwareWebView implements InAppWebVie
               (boolean) customSettings.rendererPriorityPolicy.get("waivedWhenNotVisible"));
     }
 
-    if (WebViewFeature.isFeatureSupported(WebViewFeature.SUPPRESS_ERROR_PAGE)) {
-      WebSettingsCompat.setWillSuppressErrorPage(settings, customSettings.disableDefaultErrorPage);
-    }
     if (WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
       WebSettingsCompat.setAlgorithmicDarkeningAllowed(settings, customSettings.algorithmicDarkeningAllowed);
     }
@@ -1101,11 +1098,6 @@ final public class InAppWebView extends InputAwareWebView implements InAppWebVie
         setHorizontalScrollbarTrackDrawable(new ColorDrawable(Color.parseColor(newCustomSettings.horizontalScrollbarTrackColor)));
     }
 
-    if (newSettingsMap.get("disableDefaultErrorPage") != null &&
-            !Util.objEquals(customSettings.disableDefaultErrorPage, newCustomSettings.disableDefaultErrorPage) &&
-            WebViewFeature.isFeatureSupported(WebViewFeature.SUPPRESS_ERROR_PAGE)) {
-      WebSettingsCompat.setWillSuppressErrorPage(settings, newCustomSettings.disableDefaultErrorPage);
-    }
     if (newSettingsMap.get("algorithmicDarkeningAllowed") != null &&
             !Util.objEquals(customSettings.algorithmicDarkeningAllowed, newCustomSettings.algorithmicDarkeningAllowed) &&
             WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {

--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/in_app_webview/InAppWebViewClient.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/in_app_webview/InAppWebViewClient.java
@@ -299,12 +299,6 @@ public class InAppWebViewClient extends WebViewClient {
   public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
     final InAppWebView webView = (InAppWebView) view;
 
-    if (!WebViewFeature.isFeatureSupported(WebViewFeature.SUPPRESS_ERROR_PAGE) &&
-            webView.customSettings.disableDefaultErrorPage) {
-      webView.stopLoading();
-      webView.loadUrl("about:blank");
-    }
-
     webView.isLoading = false;
     previousAuthRequestFailureCount = 0;
     credentialsProposed = null;

--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/in_app_webview/InAppWebViewClientCompat.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/in_app_webview/InAppWebViewClientCompat.java
@@ -309,12 +309,6 @@ public class InAppWebViewClientCompat extends WebViewClientCompat {
   public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
     final InAppWebView webView = (InAppWebView) view;
 
-    if (!WebViewFeature.isFeatureSupported(WebViewFeature.SUPPRESS_ERROR_PAGE) &&
-            webView.customSettings.disableDefaultErrorPage) {
-      webView.stopLoading();
-      webView.loadUrl("about:blank");
-    }
-
     webView.isLoading = false;
     previousAuthRequestFailureCount = 0;
     credentialsProposed = null;

--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/in_app_webview/InAppWebViewSettings.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/in_app_webview/InAppWebViewSettings.java
@@ -596,9 +596,6 @@ public class InAppWebViewSettings implements ISettings<InAppWebViewInterface> {
         rendererPriorityPolicy.put("waivedWhenNotVisible", webView.getRendererPriorityWaivedWhenNotVisible());
         realSettings.put("rendererPriorityPolicy", rendererPriorityPolicy);
       }
-      if (WebViewFeature.isFeatureSupported(WebViewFeature.SUPPRESS_ERROR_PAGE)) {
-        realSettings.put("disableDefaultErrorPage", WebSettingsCompat.willSuppressErrorPage(settings));
-      }
       if (WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
         realSettings.put("algorithmicDarkeningAllowed", WebSettingsCompat.isAlgorithmicDarkeningAllowed(settings));
       }

--- a/flutter_inappwebview_platform_interface/lib/src/platform_webview_feature.dart
+++ b/flutter_inappwebview_platform_interface/lib/src/platform_webview_feature.dart
@@ -32,8 +32,7 @@ abstract class PlatformWebViewFeature extends PlatformInterface {
       '`WebViewPlatform.instance` before use. For unit testing, '
       '`WebViewPlatform.instance` can be set with your own test implementation.',
     );
-    final PlatformWebViewFeature webViewFeature =
-        InAppWebViewPlatform.instance!.createPlatformWebViewFeature(params);
+    final PlatformWebViewFeature webViewFeature = InAppWebViewPlatform.instance!.createPlatformWebViewFeature(params);
     PlatformInterface.verify(webViewFeature, _token);
     return webViewFeature;
   }
@@ -82,8 +81,7 @@ abstract class PlatformWebViewFeature extends PlatformInterface {
   ///**Official Android API**: https://developer.android.com/reference/androidx/webkit/WebViewFeature#isFeatureSupported(java.lang.String)
   ///{@endtemplate}
   Future<bool> isFeatureSupported(WebViewFeature feature) {
-    throw UnimplementedError(
-        'isFeatureSupported is not implemented on the current platform');
+    throw UnimplementedError('isFeatureSupported is not implemented on the current platform');
   }
 
   ///{@template flutter_inappwebview_platform_interface.PlatformWebViewFeature.isStartupFeatureSupported}
@@ -104,8 +102,7 @@ abstract class PlatformWebViewFeature extends PlatformInterface {
   ///**Official Android API**: https://developer.android.com/reference/androidx/webkit/WebViewFeature#isFeatureSupported(java.lang.String)
   ///{@endtemplate}
   Future<bool> isStartupFeatureSupported(WebViewFeature startupFeature) {
-    throw UnimplementedError(
-        'isStartupFeatureSupported is not implemented on the current platform');
+    throw UnimplementedError('isStartupFeatureSupported is not implemented on the current platform');
   }
 }
 
@@ -121,225 +118,176 @@ class WebViewFeature_ {
   String toNativeValue() => _value;
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewController.createWebMessageChannel].
-  static const CREATE_WEB_MESSAGE_CHANNEL =
-      const WebViewFeature_._internal("CREATE_WEB_MESSAGE_CHANNEL");
+  static const CREATE_WEB_MESSAGE_CHANNEL = const WebViewFeature_._internal("CREATE_WEB_MESSAGE_CHANNEL");
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewSettings.disabledActionModeMenuItems].
-  static const DISABLED_ACTION_MODE_MENU_ITEMS =
-      const WebViewFeature_._internal("DISABLED_ACTION_MODE_MENU_ITEMS");
+  static const DISABLED_ACTION_MODE_MENU_ITEMS = const WebViewFeature_._internal("DISABLED_ACTION_MODE_MENU_ITEMS");
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewSettings.forceDark].
   static const FORCE_DARK = const WebViewFeature_._internal("FORCE_DARK");
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewSettings.forceDarkStrategy].
-  static const FORCE_DARK_STRATEGY =
-      const WebViewFeature_._internal("FORCE_DARK_STRATEGY");
+  static const FORCE_DARK_STRATEGY = const WebViewFeature_._internal("FORCE_DARK_STRATEGY");
 
   ///
-  static const GET_WEB_CHROME_CLIENT =
-      const WebViewFeature_._internal("GET_WEB_CHROME_CLIENT");
+  static const GET_WEB_CHROME_CLIENT = const WebViewFeature_._internal("GET_WEB_CHROME_CLIENT");
 
   ///
-  static const GET_WEB_VIEW_CLIENT =
-      const WebViewFeature_._internal("GET_WEB_VIEW_CLIENT");
+  static const GET_WEB_VIEW_CLIENT = const WebViewFeature_._internal("GET_WEB_VIEW_CLIENT");
 
   ///
-  static const GET_WEB_VIEW_RENDERER =
-      const WebViewFeature_._internal("GET_WEB_VIEW_RENDERER");
+  static const GET_WEB_VIEW_RENDERER = const WebViewFeature_._internal("GET_WEB_VIEW_RENDERER");
 
   ///
   static const MULTI_PROCESS = const WebViewFeature_._internal("MULTI_PROCESS");
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewSettings.offscreenPreRaster].
-  static const OFF_SCREEN_PRERASTER =
-      const WebViewFeature_._internal("OFF_SCREEN_PRERASTER");
+  static const OFF_SCREEN_PRERASTER = const WebViewFeature_._internal("OFF_SCREEN_PRERASTER");
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewController.postWebMessage].
-  static const POST_WEB_MESSAGE =
-      const WebViewFeature_._internal("POST_WEB_MESSAGE");
+  static const POST_WEB_MESSAGE = const WebViewFeature_._internal("POST_WEB_MESSAGE");
 
   ///Feature for [isFeatureSupported]. This feature covers [ProxyController.setProxyOverride] and [ProxyController.clearProxyOverride].
-  static const PROXY_OVERRIDE =
-      const WebViewFeature_._internal("PROXY_OVERRIDE");
+  static const PROXY_OVERRIDE = const WebViewFeature_._internal("PROXY_OVERRIDE");
 
   ///Feature for [isFeatureSupported]. This feature covers [ProxySettings.reverseBypassEnabled].
-  static const PROXY_OVERRIDE_REVERSE_BYPASS =
-      const WebViewFeature_._internal("PROXY_OVERRIDE_REVERSE_BYPASS");
+  static const PROXY_OVERRIDE_REVERSE_BYPASS = const WebViewFeature_._internal("PROXY_OVERRIDE_REVERSE_BYPASS");
 
   ///
-  static const RECEIVE_HTTP_ERROR =
-      const WebViewFeature_._internal("RECEIVE_HTTP_ERROR");
+  static const RECEIVE_HTTP_ERROR = const WebViewFeature_._internal("RECEIVE_HTTP_ERROR");
 
   ///
-  static const RECEIVE_WEB_RESOURCE_ERROR =
-      const WebViewFeature_._internal("RECEIVE_WEB_RESOURCE_ERROR");
+  static const RECEIVE_WEB_RESOURCE_ERROR = const WebViewFeature_._internal("RECEIVE_WEB_RESOURCE_ERROR");
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewController.setSafeBrowsingAllowlist].
-  static const SAFE_BROWSING_ALLOWLIST =
-      const WebViewFeature_._internal("SAFE_BROWSING_ALLOWLIST");
+  static const SAFE_BROWSING_ALLOWLIST = const WebViewFeature_._internal("SAFE_BROWSING_ALLOWLIST");
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewSettings.safeBrowsingEnabled].
-  static const SAFE_BROWSING_ENABLE =
-      const WebViewFeature_._internal("SAFE_BROWSING_ENABLE");
+  static const SAFE_BROWSING_ENABLE = const WebViewFeature_._internal("SAFE_BROWSING_ENABLE");
 
   ///
-  static const SAFE_BROWSING_HIT =
-      const WebViewFeature_._internal("SAFE_BROWSING_HIT");
+  static const SAFE_BROWSING_HIT = const WebViewFeature_._internal("SAFE_BROWSING_HIT");
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewController.getSafeBrowsingPrivacyPolicyUrl].
-  static const SAFE_BROWSING_PRIVACY_POLICY_URL =
-      const WebViewFeature_._internal("SAFE_BROWSING_PRIVACY_POLICY_URL");
+  static const SAFE_BROWSING_PRIVACY_POLICY_URL = const WebViewFeature_._internal("SAFE_BROWSING_PRIVACY_POLICY_URL");
 
   ///
   static const SAFE_BROWSING_RESPONSE_BACK_TO_SAFETY =
       const WebViewFeature_._internal("SAFE_BROWSING_RESPONSE_BACK_TO_SAFETY");
 
   ///
-  static const SAFE_BROWSING_RESPONSE_PROCEED =
-      const WebViewFeature_._internal("SAFE_BROWSING_RESPONSE_PROCEED");
+  static const SAFE_BROWSING_RESPONSE_PROCEED = const WebViewFeature_._internal("SAFE_BROWSING_RESPONSE_PROCEED");
 
   ///
   static const SAFE_BROWSING_RESPONSE_SHOW_INTERSTITIAL =
-      const WebViewFeature_._internal(
-          "SAFE_BROWSING_RESPONSE_SHOW_INTERSTITIAL");
+      const WebViewFeature_._internal("SAFE_BROWSING_RESPONSE_SHOW_INTERSTITIAL");
 
   ///Use [SAFE_BROWSING_ALLOWLIST] instead.
   @Deprecated('Use SAFE_BROWSING_ALLOWLIST instead')
-  static const SAFE_BROWSING_WHITELIST =
-      const WebViewFeature_._internal("SAFE_BROWSING_WHITELIST");
+  static const SAFE_BROWSING_WHITELIST = const WebViewFeature_._internal("SAFE_BROWSING_WHITELIST");
 
   ///Feature for [isFeatureSupported]. This feature covers [ServiceWorkerController].
-  static const SERVICE_WORKER_BASIC_USAGE =
-      const WebViewFeature_._internal("SERVICE_WORKER_BASIC_USAGE");
+  static const SERVICE_WORKER_BASIC_USAGE = const WebViewFeature_._internal("SERVICE_WORKER_BASIC_USAGE");
 
   ///Feature for [isFeatureSupported]. This feature covers [ServiceWorkerController.setBlockNetworkLoads] and [ServiceWorkerController.getBlockNetworkLoads].
   static const SERVICE_WORKER_BLOCK_NETWORK_LOADS =
       const WebViewFeature_._internal("SERVICE_WORKER_BLOCK_NETWORK_LOADS");
 
   ///Feature for [isFeatureSupported]. This feature covers [ServiceWorkerController.setCacheMode] and [ServiceWorkerController.getCacheMode].
-  static const SERVICE_WORKER_CACHE_MODE =
-      const WebViewFeature_._internal("SERVICE_WORKER_CACHE_MODE");
+  static const SERVICE_WORKER_CACHE_MODE = const WebViewFeature_._internal("SERVICE_WORKER_CACHE_MODE");
 
   ///Feature for [isFeatureSupported]. This feature covers [ServiceWorkerController.setAllowContentAccess] and [ServiceWorkerController.getAllowContentAccess].
-  static const SERVICE_WORKER_CONTENT_ACCESS =
-      const WebViewFeature_._internal("SERVICE_WORKER_CONTENT_ACCESS");
+  static const SERVICE_WORKER_CONTENT_ACCESS = const WebViewFeature_._internal("SERVICE_WORKER_CONTENT_ACCESS");
 
   ///Feature for [isFeatureSupported]. This feature covers [ServiceWorkerController.setAllowFileAccess] and [ServiceWorkerController.getAllowFileAccess].
-  static const SERVICE_WORKER_FILE_ACCESS =
-      const WebViewFeature_._internal("SERVICE_WORKER_FILE_ACCESS");
+  static const SERVICE_WORKER_FILE_ACCESS = const WebViewFeature_._internal("SERVICE_WORKER_FILE_ACCESS");
 
   ///Feature for [isFeatureSupported]. This feature covers [ServiceWorkerClient.shouldInterceptRequest].
   static const SERVICE_WORKER_SHOULD_INTERCEPT_REQUEST =
-      const WebViewFeature_._internal(
-          "SERVICE_WORKER_SHOULD_INTERCEPT_REQUEST");
+      const WebViewFeature_._internal("SERVICE_WORKER_SHOULD_INTERCEPT_REQUEST");
 
   ///
-  static const SHOULD_OVERRIDE_WITH_REDIRECTS =
-      const WebViewFeature_._internal("SHOULD_OVERRIDE_WITH_REDIRECTS");
+  static const SHOULD_OVERRIDE_WITH_REDIRECTS = const WebViewFeature_._internal("SHOULD_OVERRIDE_WITH_REDIRECTS");
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewController.startSafeBrowsing].
-  static const START_SAFE_BROWSING =
-      const WebViewFeature_._internal("START_SAFE_BROWSING");
+  static const START_SAFE_BROWSING = const WebViewFeature_._internal("START_SAFE_BROWSING");
 
   ///
-  static const TRACING_CONTROLLER_BASIC_USAGE =
-      const WebViewFeature_._internal("TRACING_CONTROLLER_BASIC_USAGE");
+  static const TRACING_CONTROLLER_BASIC_USAGE = const WebViewFeature_._internal("TRACING_CONTROLLER_BASIC_USAGE");
 
   ///
-  static const VISUAL_STATE_CALLBACK =
-      const WebViewFeature_._internal("VISUAL_STATE_CALLBACK");
+  static const VISUAL_STATE_CALLBACK = const WebViewFeature_._internal("VISUAL_STATE_CALLBACK");
 
   ///
-  static const WEB_MESSAGE_CALLBACK_ON_MESSAGE =
-      const WebViewFeature_._internal("WEB_MESSAGE_CALLBACK_ON_MESSAGE");
+  static const WEB_MESSAGE_CALLBACK_ON_MESSAGE = const WebViewFeature_._internal("WEB_MESSAGE_CALLBACK_ON_MESSAGE");
 
   ///Feature for [isFeatureSupported]. This feature covers [WebMessageListener].
-  static const WEB_MESSAGE_LISTENER =
-      const WebViewFeature_._internal("WEB_MESSAGE_LISTENER");
+  static const WEB_MESSAGE_LISTENER = const WebViewFeature_._internal("WEB_MESSAGE_LISTENER");
 
   ///
-  static const WEB_MESSAGE_PORT_CLOSE =
-      const WebViewFeature_._internal("WEB_MESSAGE_PORT_CLOSE");
+  static const WEB_MESSAGE_PORT_CLOSE = const WebViewFeature_._internal("WEB_MESSAGE_PORT_CLOSE");
 
   ///
-  static const WEB_MESSAGE_PORT_POST_MESSAGE =
-      const WebViewFeature_._internal("WEB_MESSAGE_PORT_POST_MESSAGE");
+  static const WEB_MESSAGE_PORT_POST_MESSAGE = const WebViewFeature_._internal("WEB_MESSAGE_PORT_POST_MESSAGE");
 
   ///
   static const WEB_MESSAGE_PORT_SET_MESSAGE_CALLBACK =
       const WebViewFeature_._internal("WEB_MESSAGE_PORT_SET_MESSAGE_CALLBACK");
 
   ///
-  static const WEB_RESOURCE_ERROR_GET_CODE =
-      const WebViewFeature_._internal("WEB_RESOURCE_ERROR_GET_CODE");
+  static const WEB_RESOURCE_ERROR_GET_CODE = const WebViewFeature_._internal("WEB_RESOURCE_ERROR_GET_CODE");
 
   ///
   static const WEB_RESOURCE_ERROR_GET_DESCRIPTION =
       const WebViewFeature_._internal("WEB_RESOURCE_ERROR_GET_DESCRIPTION");
 
   ///
-  static const WEB_RESOURCE_REQUEST_IS_REDIRECT =
-      const WebViewFeature_._internal("WEB_RESOURCE_REQUEST_IS_REDIRECT");
+  static const WEB_RESOURCE_REQUEST_IS_REDIRECT = const WebViewFeature_._internal("WEB_RESOURCE_REQUEST_IS_REDIRECT");
 
   ///
   static const WEB_VIEW_RENDERER_CLIENT_BASIC_USAGE =
       const WebViewFeature_._internal("WEB_VIEW_RENDERER_CLIENT_BASIC_USAGE");
 
   ///
-  static const WEB_VIEW_RENDERER_TERMINATE =
-      const WebViewFeature_._internal("WEB_VIEW_RENDERER_TERMINATE");
+  static const WEB_VIEW_RENDERER_TERMINATE = const WebViewFeature_._internal("WEB_VIEW_RENDERER_TERMINATE");
 
   ///Feature for [isFeatureSupported]. This feature covers [UserScriptInjectionTime.AT_DOCUMENT_START].
-  static const DOCUMENT_START_SCRIPT =
-      const WebViewFeature_._internal("DOCUMENT_START_SCRIPT");
-
-  ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewSettings.willSuppressErrorPage].
-  static const SUPPRESS_ERROR_PAGE =
-      const WebViewFeature_._internal("SUPPRESS_ERROR_PAGE");
+  static const DOCUMENT_START_SCRIPT = const WebViewFeature_._internal("DOCUMENT_START_SCRIPT");
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewSettings.algorithmicDarkeningAllowed].
-  static const ALGORITHMIC_DARKENING =
-      const WebViewFeature_._internal("ALGORITHMIC_DARKENING");
+  static const ALGORITHMIC_DARKENING = const WebViewFeature_._internal("ALGORITHMIC_DARKENING");
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewSettings.enterpriseAuthenticationAppLinkPolicyEnabled].
   static const ENTERPRISE_AUTHENTICATION_APP_LINK_POLICY =
-      const WebViewFeature_._internal(
-          "ENTERPRISE_AUTHENTICATION_APP_LINK_POLICY");
+      const WebViewFeature_._internal("ENTERPRISE_AUTHENTICATION_APP_LINK_POLICY");
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewController.getVariationsHeader].
-  static const GET_VARIATIONS_HEADER =
-      const WebViewFeature_._internal("GET_VARIATIONS_HEADER");
+  static const GET_VARIATIONS_HEADER = const WebViewFeature_._internal("GET_VARIATIONS_HEADER");
 
   ///Feature for [isFeatureSupported]. This feature covers cookie attributes of [CookieManager.getCookie] and [CookieManager.getCookies] methods.
-  static const GET_COOKIE_INFO =
-      const WebViewFeature_._internal("GET_COOKIE_INFO");
+  static const GET_COOKIE_INFO = const WebViewFeature_._internal("GET_COOKIE_INFO");
 
   ///Feature for [isFeatureSupported]. This feature covers cookie attributes of [CookieManager.getCookie] and [CookieManager.getCookies] methods.
-  static const REQUESTED_WITH_HEADER_ALLOW_LIST =
-      const WebViewFeature_._internal("REQUESTED_WITH_HEADER_ALLOW_LIST");
+  static const REQUESTED_WITH_HEADER_ALLOW_LIST = const WebViewFeature_._internal("REQUESTED_WITH_HEADER_ALLOW_LIST");
 
   ///Feature for [isFeatureSupported]. This feature covers [WebMessagePort.postMessage] with `ArrayBuffer` type,
   ///[InAppWebViewController.postWebMessage] with `ArrayBuffer` type, and [JavaScriptReplyProxy.postMessage] with `ArrayBuffer` type.
-  static const WEB_MESSAGE_ARRAY_BUFFER =
-      const WebViewFeature_._internal("WEB_MESSAGE_ARRAY_BUFFER");
+  static const WEB_MESSAGE_ARRAY_BUFFER = const WebViewFeature_._internal("WEB_MESSAGE_ARRAY_BUFFER");
 
   ///Feature for [isStartupFeatureSupported]. This feature covers [ProcessGlobalConfigSettings.dataDirectorySuffix].
   static const STARTUP_FEATURE_SET_DATA_DIRECTORY_SUFFIX =
-      const WebViewFeature_._internal(
-          "STARTUP_FEATURE_SET_DATA_DIRECTORY_SUFFIX");
+      const WebViewFeature_._internal("STARTUP_FEATURE_SET_DATA_DIRECTORY_SUFFIX");
 
   ///Feature for [isStartupFeatureSupported]. This feature covers [ProcessGlobalConfigSettings.directoryBasePaths].
   static const STARTUP_FEATURE_SET_DIRECTORY_BASE_PATHS =
-      const WebViewFeature_._internal(
-          "STARTUP_FEATURE_SET_DIRECTORY_BASE_PATHS");
+      const WebViewFeature_._internal("STARTUP_FEATURE_SET_DIRECTORY_BASE_PATHS");
 
   ///{@macro flutter_inappwebview_platform_interface.PlatformWebViewFeature.isFeatureSupported}
   static Future<bool> isFeatureSupported(WebViewFeature feature) =>
       PlatformWebViewFeature.static().isFeatureSupported(feature);
 
   ///{@macro flutter_inappwebview_platform_interface.PlatformWebViewFeature.isStartupFeatureSupported}
-  static Future<bool> isStartupFeatureSupported(
-          WebViewFeature startupFeature) =>
+  static Future<bool> isStartupFeatureSupported(WebViewFeature startupFeature) =>
       PlatformWebViewFeature.static().isStartupFeatureSupported(startupFeature);
 }
 
@@ -357,78 +305,61 @@ class AndroidWebViewFeature_ {
   String toNativeValue() => _value;
 
   ///
-  static const CREATE_WEB_MESSAGE_CHANNEL =
-      const AndroidWebViewFeature_._internal("CREATE_WEB_MESSAGE_CHANNEL");
+  static const CREATE_WEB_MESSAGE_CHANNEL = const AndroidWebViewFeature_._internal("CREATE_WEB_MESSAGE_CHANNEL");
 
   ///
   static const DISABLED_ACTION_MODE_MENU_ITEMS =
       const AndroidWebViewFeature_._internal("DISABLED_ACTION_MODE_MENU_ITEMS");
 
   ///
-  static const FORCE_DARK =
-      const AndroidWebViewFeature_._internal("FORCE_DARK");
+  static const FORCE_DARK = const AndroidWebViewFeature_._internal("FORCE_DARK");
 
   ///
-  static const FORCE_DARK_STRATEGY =
-      const AndroidWebViewFeature_._internal("FORCE_DARK_STRATEGY");
+  static const FORCE_DARK_STRATEGY = const AndroidWebViewFeature_._internal("FORCE_DARK_STRATEGY");
 
   ///
-  static const GET_WEB_CHROME_CLIENT =
-      const AndroidWebViewFeature_._internal("GET_WEB_CHROME_CLIENT");
+  static const GET_WEB_CHROME_CLIENT = const AndroidWebViewFeature_._internal("GET_WEB_CHROME_CLIENT");
 
   ///
-  static const GET_WEB_VIEW_CLIENT =
-      const AndroidWebViewFeature_._internal("GET_WEB_VIEW_CLIENT");
+  static const GET_WEB_VIEW_CLIENT = const AndroidWebViewFeature_._internal("GET_WEB_VIEW_CLIENT");
 
   ///
-  static const GET_WEB_VIEW_RENDERER =
-      const AndroidWebViewFeature_._internal("GET_WEB_VIEW_RENDERER");
+  static const GET_WEB_VIEW_RENDERER = const AndroidWebViewFeature_._internal("GET_WEB_VIEW_RENDERER");
 
   ///
-  static const MULTI_PROCESS =
-      const AndroidWebViewFeature_._internal("MULTI_PROCESS");
+  static const MULTI_PROCESS = const AndroidWebViewFeature_._internal("MULTI_PROCESS");
 
   ///
-  static const OFF_SCREEN_PRERASTER =
-      const AndroidWebViewFeature_._internal("OFF_SCREEN_PRERASTER");
+  static const OFF_SCREEN_PRERASTER = const AndroidWebViewFeature_._internal("OFF_SCREEN_PRERASTER");
 
   ///
-  static const POST_WEB_MESSAGE =
-      const AndroidWebViewFeature_._internal("POST_WEB_MESSAGE");
+  static const POST_WEB_MESSAGE = const AndroidWebViewFeature_._internal("POST_WEB_MESSAGE");
 
   ///
-  static const PROXY_OVERRIDE =
-      const AndroidWebViewFeature_._internal("PROXY_OVERRIDE");
+  static const PROXY_OVERRIDE = const AndroidWebViewFeature_._internal("PROXY_OVERRIDE");
 
   ///
-  static const RECEIVE_HTTP_ERROR =
-      const AndroidWebViewFeature_._internal("RECEIVE_HTTP_ERROR");
+  static const RECEIVE_HTTP_ERROR = const AndroidWebViewFeature_._internal("RECEIVE_HTTP_ERROR");
 
   ///
-  static const RECEIVE_WEB_RESOURCE_ERROR =
-      const AndroidWebViewFeature_._internal("RECEIVE_WEB_RESOURCE_ERROR");
+  static const RECEIVE_WEB_RESOURCE_ERROR = const AndroidWebViewFeature_._internal("RECEIVE_WEB_RESOURCE_ERROR");
 
   ///
-  static const SAFE_BROWSING_ALLOWLIST =
-      const AndroidWebViewFeature_._internal("SAFE_BROWSING_ALLOWLIST");
+  static const SAFE_BROWSING_ALLOWLIST = const AndroidWebViewFeature_._internal("SAFE_BROWSING_ALLOWLIST");
 
   ///
-  static const SAFE_BROWSING_ENABLE =
-      const AndroidWebViewFeature_._internal("SAFE_BROWSING_ENABLE");
+  static const SAFE_BROWSING_ENABLE = const AndroidWebViewFeature_._internal("SAFE_BROWSING_ENABLE");
 
   ///
-  static const SAFE_BROWSING_HIT =
-      const AndroidWebViewFeature_._internal("SAFE_BROWSING_HIT");
+  static const SAFE_BROWSING_HIT = const AndroidWebViewFeature_._internal("SAFE_BROWSING_HIT");
 
   ///
   static const SAFE_BROWSING_PRIVACY_POLICY_URL =
-      const AndroidWebViewFeature_._internal(
-          "SAFE_BROWSING_PRIVACY_POLICY_URL");
+      const AndroidWebViewFeature_._internal("SAFE_BROWSING_PRIVACY_POLICY_URL");
 
   ///
   static const SAFE_BROWSING_RESPONSE_BACK_TO_SAFETY =
-      const AndroidWebViewFeature_._internal(
-          "SAFE_BROWSING_RESPONSE_BACK_TO_SAFETY");
+      const AndroidWebViewFeature_._internal("SAFE_BROWSING_RESPONSE_BACK_TO_SAFETY");
 
   ///
   static const SAFE_BROWSING_RESPONSE_PROCEED =
@@ -436,120 +367,93 @@ class AndroidWebViewFeature_ {
 
   ///
   static const SAFE_BROWSING_RESPONSE_SHOW_INTERSTITIAL =
-      const AndroidWebViewFeature_._internal(
-          "SAFE_BROWSING_RESPONSE_SHOW_INTERSTITIAL");
+      const AndroidWebViewFeature_._internal("SAFE_BROWSING_RESPONSE_SHOW_INTERSTITIAL");
 
   ///Use [SAFE_BROWSING_ALLOWLIST] instead.
   @Deprecated('Use SAFE_BROWSING_ALLOWLIST instead')
-  static const SAFE_BROWSING_WHITELIST =
-      const AndroidWebViewFeature_._internal("SAFE_BROWSING_WHITELIST");
+  static const SAFE_BROWSING_WHITELIST = const AndroidWebViewFeature_._internal("SAFE_BROWSING_WHITELIST");
 
   ///
-  static const SERVICE_WORKER_BASIC_USAGE =
-      const AndroidWebViewFeature_._internal("SERVICE_WORKER_BASIC_USAGE");
+  static const SERVICE_WORKER_BASIC_USAGE = const AndroidWebViewFeature_._internal("SERVICE_WORKER_BASIC_USAGE");
 
   ///
   static const SERVICE_WORKER_BLOCK_NETWORK_LOADS =
-      const AndroidWebViewFeature_._internal(
-          "SERVICE_WORKER_BLOCK_NETWORK_LOADS");
+      const AndroidWebViewFeature_._internal("SERVICE_WORKER_BLOCK_NETWORK_LOADS");
 
   ///
-  static const SERVICE_WORKER_CACHE_MODE =
-      const AndroidWebViewFeature_._internal("SERVICE_WORKER_CACHE_MODE");
+  static const SERVICE_WORKER_CACHE_MODE = const AndroidWebViewFeature_._internal("SERVICE_WORKER_CACHE_MODE");
 
   ///
-  static const SERVICE_WORKER_CONTENT_ACCESS =
-      const AndroidWebViewFeature_._internal("SERVICE_WORKER_CONTENT_ACCESS");
+  static const SERVICE_WORKER_CONTENT_ACCESS = const AndroidWebViewFeature_._internal("SERVICE_WORKER_CONTENT_ACCESS");
 
   ///
-  static const SERVICE_WORKER_FILE_ACCESS =
-      const AndroidWebViewFeature_._internal("SERVICE_WORKER_FILE_ACCESS");
+  static const SERVICE_WORKER_FILE_ACCESS = const AndroidWebViewFeature_._internal("SERVICE_WORKER_FILE_ACCESS");
 
   ///
   static const SERVICE_WORKER_SHOULD_INTERCEPT_REQUEST =
-      const AndroidWebViewFeature_._internal(
-          "SERVICE_WORKER_SHOULD_INTERCEPT_REQUEST");
+      const AndroidWebViewFeature_._internal("SERVICE_WORKER_SHOULD_INTERCEPT_REQUEST");
 
   ///
   static const SHOULD_OVERRIDE_WITH_REDIRECTS =
       const AndroidWebViewFeature_._internal("SHOULD_OVERRIDE_WITH_REDIRECTS");
 
   ///
-  static const START_SAFE_BROWSING =
-      const AndroidWebViewFeature_._internal("START_SAFE_BROWSING");
+  static const START_SAFE_BROWSING = const AndroidWebViewFeature_._internal("START_SAFE_BROWSING");
 
   ///
   static const TRACING_CONTROLLER_BASIC_USAGE =
       const AndroidWebViewFeature_._internal("TRACING_CONTROLLER_BASIC_USAGE");
 
   ///
-  static const VISUAL_STATE_CALLBACK =
-      const AndroidWebViewFeature_._internal("VISUAL_STATE_CALLBACK");
+  static const VISUAL_STATE_CALLBACK = const AndroidWebViewFeature_._internal("VISUAL_STATE_CALLBACK");
 
   ///
   static const WEB_MESSAGE_CALLBACK_ON_MESSAGE =
       const AndroidWebViewFeature_._internal("WEB_MESSAGE_CALLBACK_ON_MESSAGE");
 
   ///
-  static const WEB_MESSAGE_LISTENER =
-      const AndroidWebViewFeature_._internal("WEB_MESSAGE_LISTENER");
+  static const WEB_MESSAGE_LISTENER = const AndroidWebViewFeature_._internal("WEB_MESSAGE_LISTENER");
 
   ///
-  static const WEB_MESSAGE_PORT_CLOSE =
-      const AndroidWebViewFeature_._internal("WEB_MESSAGE_PORT_CLOSE");
+  static const WEB_MESSAGE_PORT_CLOSE = const AndroidWebViewFeature_._internal("WEB_MESSAGE_PORT_CLOSE");
 
   ///
-  static const WEB_MESSAGE_PORT_POST_MESSAGE =
-      const AndroidWebViewFeature_._internal("WEB_MESSAGE_PORT_POST_MESSAGE");
+  static const WEB_MESSAGE_PORT_POST_MESSAGE = const AndroidWebViewFeature_._internal("WEB_MESSAGE_PORT_POST_MESSAGE");
 
   ///
   static const WEB_MESSAGE_PORT_SET_MESSAGE_CALLBACK =
-      const AndroidWebViewFeature_._internal(
-          "WEB_MESSAGE_PORT_SET_MESSAGE_CALLBACK");
+      const AndroidWebViewFeature_._internal("WEB_MESSAGE_PORT_SET_MESSAGE_CALLBACK");
 
   ///
-  static const WEB_RESOURCE_ERROR_GET_CODE =
-      const AndroidWebViewFeature_._internal("WEB_RESOURCE_ERROR_GET_CODE");
+  static const WEB_RESOURCE_ERROR_GET_CODE = const AndroidWebViewFeature_._internal("WEB_RESOURCE_ERROR_GET_CODE");
 
   ///
   static const WEB_RESOURCE_ERROR_GET_DESCRIPTION =
-      const AndroidWebViewFeature_._internal(
-          "WEB_RESOURCE_ERROR_GET_DESCRIPTION");
+      const AndroidWebViewFeature_._internal("WEB_RESOURCE_ERROR_GET_DESCRIPTION");
 
   ///
   static const WEB_RESOURCE_REQUEST_IS_REDIRECT =
-      const AndroidWebViewFeature_._internal(
-          "WEB_RESOURCE_REQUEST_IS_REDIRECT");
+      const AndroidWebViewFeature_._internal("WEB_RESOURCE_REQUEST_IS_REDIRECT");
 
   ///
   static const WEB_VIEW_RENDERER_CLIENT_BASIC_USAGE =
-      const AndroidWebViewFeature_._internal(
-          "WEB_VIEW_RENDERER_CLIENT_BASIC_USAGE");
+      const AndroidWebViewFeature_._internal("WEB_VIEW_RENDERER_CLIENT_BASIC_USAGE");
 
   ///
-  static const WEB_VIEW_RENDERER_TERMINATE =
-      const AndroidWebViewFeature_._internal("WEB_VIEW_RENDERER_TERMINATE");
+  static const WEB_VIEW_RENDERER_TERMINATE = const AndroidWebViewFeature_._internal("WEB_VIEW_RENDERER_TERMINATE");
 
   ///Feature for [isFeatureSupported]. This feature covers [UserScriptInjectionTime.AT_DOCUMENT_START].
-  static const DOCUMENT_START_SCRIPT =
-      const AndroidWebViewFeature_._internal("DOCUMENT_START_SCRIPT");
-
-  ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewSettings.willSuppressErrorPage].
-  static const SUPPRESS_ERROR_PAGE =
-      const AndroidWebViewFeature_._internal("SUPPRESS_ERROR_PAGE");
+  static const DOCUMENT_START_SCRIPT = const AndroidWebViewFeature_._internal("DOCUMENT_START_SCRIPT");
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewSettings.algorithmicDarkeningAllowed].
-  static const ALGORITHMIC_DARKENING =
-      const AndroidWebViewFeature_._internal("ALGORITHMIC_DARKENING");
+  static const ALGORITHMIC_DARKENING = const AndroidWebViewFeature_._internal("ALGORITHMIC_DARKENING");
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewSettings.requestedWithHeaderMode].
-  static const REQUESTED_WITH_HEADER_CONTROL =
-      const AndroidWebViewFeature_._internal("REQUESTED_WITH_HEADER_CONTROL");
+  static const REQUESTED_WITH_HEADER_CONTROL = const AndroidWebViewFeature_._internal("REQUESTED_WITH_HEADER_CONTROL");
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewSettings.enterpriseAuthenticationAppLinkPolicyEnabled].
   static const ENTERPRISE_AUTHENTICATION_APP_LINK_POLICY =
-      const AndroidWebViewFeature_._internal(
-          "ENTERPRISE_AUTHENTICATION_APP_LINK_POLICY");
+      const AndroidWebViewFeature_._internal("ENTERPRISE_AUTHENTICATION_APP_LINK_POLICY");
 
   ///Return whether a feature is supported at run-time. On devices running Android version `Build.VERSION_CODES.LOLLIPOP` and higher,
   ///this will check whether a feature is supported, depending on the combination of the desired feature, the Android version of device,
@@ -557,6 +461,5 @@ class AndroidWebViewFeature_ {
   ///
   ///**Official Android API**: https://developer.android.com/reference/androidx/webkit/WebViewFeature#isFeatureSupported(java.lang.String)
   static Future<bool> isFeatureSupported(AndroidWebViewFeature feature) =>
-      PlatformWebViewFeature.static().isFeatureSupported(
-          WebViewFeature.fromNativeValue(feature.toNativeValue())!);
+      PlatformWebViewFeature.static().isFeatureSupported(WebViewFeature.fromNativeValue(feature.toNativeValue())!);
 }

--- a/flutter_inappwebview_platform_interface/lib/src/platform_webview_feature.g.dart
+++ b/flutter_inappwebview_platform_interface/lib/src/platform_webview_feature.g.dart
@@ -12,228 +12,191 @@ class WebViewFeature {
   final String _nativeValue;
   const WebViewFeature._internal(this._value, this._nativeValue);
 // ignore: unused_element
-  factory WebViewFeature._internalMultiPlatform(
-          String value, Function nativeValue) =>
+  factory WebViewFeature._internalMultiPlatform(String value, Function nativeValue) =>
       WebViewFeature._internal(value, nativeValue());
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewSettings.algorithmicDarkeningAllowed].
-  static const ALGORITHMIC_DARKENING = WebViewFeature._internal(
-      'ALGORITHMIC_DARKENING', 'ALGORITHMIC_DARKENING');
+  static const ALGORITHMIC_DARKENING = WebViewFeature._internal('ALGORITHMIC_DARKENING', 'ALGORITHMIC_DARKENING');
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewController.createWebMessageChannel].
-  static const CREATE_WEB_MESSAGE_CHANNEL = WebViewFeature._internal(
-      'CREATE_WEB_MESSAGE_CHANNEL', 'CREATE_WEB_MESSAGE_CHANNEL');
+  static const CREATE_WEB_MESSAGE_CHANNEL =
+      WebViewFeature._internal('CREATE_WEB_MESSAGE_CHANNEL', 'CREATE_WEB_MESSAGE_CHANNEL');
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewSettings.disabledActionModeMenuItems].
-  static const DISABLED_ACTION_MODE_MENU_ITEMS = WebViewFeature._internal(
-      'DISABLED_ACTION_MODE_MENU_ITEMS', 'DISABLED_ACTION_MODE_MENU_ITEMS');
+  static const DISABLED_ACTION_MODE_MENU_ITEMS =
+      WebViewFeature._internal('DISABLED_ACTION_MODE_MENU_ITEMS', 'DISABLED_ACTION_MODE_MENU_ITEMS');
 
   ///Feature for [isFeatureSupported]. This feature covers [UserScriptInjectionTime.AT_DOCUMENT_START].
-  static const DOCUMENT_START_SCRIPT = WebViewFeature._internal(
-      'DOCUMENT_START_SCRIPT', 'DOCUMENT_START_SCRIPT');
+  static const DOCUMENT_START_SCRIPT = WebViewFeature._internal('DOCUMENT_START_SCRIPT', 'DOCUMENT_START_SCRIPT');
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewSettings.enterpriseAuthenticationAppLinkPolicyEnabled].
-  static const ENTERPRISE_AUTHENTICATION_APP_LINK_POLICY =
-      WebViewFeature._internal('ENTERPRISE_AUTHENTICATION_APP_LINK_POLICY',
-          'ENTERPRISE_AUTHENTICATION_APP_LINK_POLICY');
+  static const ENTERPRISE_AUTHENTICATION_APP_LINK_POLICY = WebViewFeature._internal(
+      'ENTERPRISE_AUTHENTICATION_APP_LINK_POLICY', 'ENTERPRISE_AUTHENTICATION_APP_LINK_POLICY');
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewSettings.forceDark].
-  static const FORCE_DARK =
-      WebViewFeature._internal('FORCE_DARK', 'FORCE_DARK');
+  static const FORCE_DARK = WebViewFeature._internal('FORCE_DARK', 'FORCE_DARK');
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewSettings.forceDarkStrategy].
-  static const FORCE_DARK_STRATEGY =
-      WebViewFeature._internal('FORCE_DARK_STRATEGY', 'FORCE_DARK_STRATEGY');
+  static const FORCE_DARK_STRATEGY = WebViewFeature._internal('FORCE_DARK_STRATEGY', 'FORCE_DARK_STRATEGY');
 
   ///Feature for [isFeatureSupported]. This feature covers cookie attributes of [CookieManager.getCookie] and [CookieManager.getCookies] methods.
-  static const GET_COOKIE_INFO =
-      WebViewFeature._internal('GET_COOKIE_INFO', 'GET_COOKIE_INFO');
+  static const GET_COOKIE_INFO = WebViewFeature._internal('GET_COOKIE_INFO', 'GET_COOKIE_INFO');
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewController.getVariationsHeader].
-  static const GET_VARIATIONS_HEADER = WebViewFeature._internal(
-      'GET_VARIATIONS_HEADER', 'GET_VARIATIONS_HEADER');
+  static const GET_VARIATIONS_HEADER = WebViewFeature._internal('GET_VARIATIONS_HEADER', 'GET_VARIATIONS_HEADER');
 
   ///
-  static const GET_WEB_CHROME_CLIENT = WebViewFeature._internal(
-      'GET_WEB_CHROME_CLIENT', 'GET_WEB_CHROME_CLIENT');
+  static const GET_WEB_CHROME_CLIENT = WebViewFeature._internal('GET_WEB_CHROME_CLIENT', 'GET_WEB_CHROME_CLIENT');
 
   ///
-  static const GET_WEB_VIEW_CLIENT =
-      WebViewFeature._internal('GET_WEB_VIEW_CLIENT', 'GET_WEB_VIEW_CLIENT');
+  static const GET_WEB_VIEW_CLIENT = WebViewFeature._internal('GET_WEB_VIEW_CLIENT', 'GET_WEB_VIEW_CLIENT');
 
   ///
-  static const GET_WEB_VIEW_RENDERER = WebViewFeature._internal(
-      'GET_WEB_VIEW_RENDERER', 'GET_WEB_VIEW_RENDERER');
+  static const GET_WEB_VIEW_RENDERER = WebViewFeature._internal('GET_WEB_VIEW_RENDERER', 'GET_WEB_VIEW_RENDERER');
 
   ///
-  static const MULTI_PROCESS =
-      WebViewFeature._internal('MULTI_PROCESS', 'MULTI_PROCESS');
+  static const MULTI_PROCESS = WebViewFeature._internal('MULTI_PROCESS', 'MULTI_PROCESS');
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewSettings.offscreenPreRaster].
-  static const OFF_SCREEN_PRERASTER =
-      WebViewFeature._internal('OFF_SCREEN_PRERASTER', 'OFF_SCREEN_PRERASTER');
+  static const OFF_SCREEN_PRERASTER = WebViewFeature._internal('OFF_SCREEN_PRERASTER', 'OFF_SCREEN_PRERASTER');
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewController.postWebMessage].
-  static const POST_WEB_MESSAGE =
-      WebViewFeature._internal('POST_WEB_MESSAGE', 'POST_WEB_MESSAGE');
+  static const POST_WEB_MESSAGE = WebViewFeature._internal('POST_WEB_MESSAGE', 'POST_WEB_MESSAGE');
 
   ///Feature for [isFeatureSupported]. This feature covers [ProxyController.setProxyOverride] and [ProxyController.clearProxyOverride].
-  static const PROXY_OVERRIDE =
-      WebViewFeature._internal('PROXY_OVERRIDE', 'PROXY_OVERRIDE');
+  static const PROXY_OVERRIDE = WebViewFeature._internal('PROXY_OVERRIDE', 'PROXY_OVERRIDE');
 
   ///Feature for [isFeatureSupported]. This feature covers [ProxySettings.reverseBypassEnabled].
-  static const PROXY_OVERRIDE_REVERSE_BYPASS = WebViewFeature._internal(
-      'PROXY_OVERRIDE_REVERSE_BYPASS', 'PROXY_OVERRIDE_REVERSE_BYPASS');
+  static const PROXY_OVERRIDE_REVERSE_BYPASS =
+      WebViewFeature._internal('PROXY_OVERRIDE_REVERSE_BYPASS', 'PROXY_OVERRIDE_REVERSE_BYPASS');
 
   ///
-  static const RECEIVE_HTTP_ERROR =
-      WebViewFeature._internal('RECEIVE_HTTP_ERROR', 'RECEIVE_HTTP_ERROR');
+  static const RECEIVE_HTTP_ERROR = WebViewFeature._internal('RECEIVE_HTTP_ERROR', 'RECEIVE_HTTP_ERROR');
 
   ///
-  static const RECEIVE_WEB_RESOURCE_ERROR = WebViewFeature._internal(
-      'RECEIVE_WEB_RESOURCE_ERROR', 'RECEIVE_WEB_RESOURCE_ERROR');
+  static const RECEIVE_WEB_RESOURCE_ERROR =
+      WebViewFeature._internal('RECEIVE_WEB_RESOURCE_ERROR', 'RECEIVE_WEB_RESOURCE_ERROR');
 
   ///Feature for [isFeatureSupported]. This feature covers cookie attributes of [CookieManager.getCookie] and [CookieManager.getCookies] methods.
-  static const REQUESTED_WITH_HEADER_ALLOW_LIST = WebViewFeature._internal(
-      'REQUESTED_WITH_HEADER_ALLOW_LIST', 'REQUESTED_WITH_HEADER_ALLOW_LIST');
+  static const REQUESTED_WITH_HEADER_ALLOW_LIST =
+      WebViewFeature._internal('REQUESTED_WITH_HEADER_ALLOW_LIST', 'REQUESTED_WITH_HEADER_ALLOW_LIST');
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewController.setSafeBrowsingAllowlist].
-  static const SAFE_BROWSING_ALLOWLIST = WebViewFeature._internal(
-      'SAFE_BROWSING_ALLOWLIST', 'SAFE_BROWSING_ALLOWLIST');
+  static const SAFE_BROWSING_ALLOWLIST = WebViewFeature._internal('SAFE_BROWSING_ALLOWLIST', 'SAFE_BROWSING_ALLOWLIST');
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewSettings.safeBrowsingEnabled].
-  static const SAFE_BROWSING_ENABLE =
-      WebViewFeature._internal('SAFE_BROWSING_ENABLE', 'SAFE_BROWSING_ENABLE');
+  static const SAFE_BROWSING_ENABLE = WebViewFeature._internal('SAFE_BROWSING_ENABLE', 'SAFE_BROWSING_ENABLE');
 
   ///
-  static const SAFE_BROWSING_HIT =
-      WebViewFeature._internal('SAFE_BROWSING_HIT', 'SAFE_BROWSING_HIT');
+  static const SAFE_BROWSING_HIT = WebViewFeature._internal('SAFE_BROWSING_HIT', 'SAFE_BROWSING_HIT');
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewController.getSafeBrowsingPrivacyPolicyUrl].
-  static const SAFE_BROWSING_PRIVACY_POLICY_URL = WebViewFeature._internal(
-      'SAFE_BROWSING_PRIVACY_POLICY_URL', 'SAFE_BROWSING_PRIVACY_POLICY_URL');
+  static const SAFE_BROWSING_PRIVACY_POLICY_URL =
+      WebViewFeature._internal('SAFE_BROWSING_PRIVACY_POLICY_URL', 'SAFE_BROWSING_PRIVACY_POLICY_URL');
 
   ///
-  static const SAFE_BROWSING_RESPONSE_BACK_TO_SAFETY = WebViewFeature._internal(
-      'SAFE_BROWSING_RESPONSE_BACK_TO_SAFETY',
-      'SAFE_BROWSING_RESPONSE_BACK_TO_SAFETY');
+  static const SAFE_BROWSING_RESPONSE_BACK_TO_SAFETY =
+      WebViewFeature._internal('SAFE_BROWSING_RESPONSE_BACK_TO_SAFETY', 'SAFE_BROWSING_RESPONSE_BACK_TO_SAFETY');
 
   ///
-  static const SAFE_BROWSING_RESPONSE_PROCEED = WebViewFeature._internal(
-      'SAFE_BROWSING_RESPONSE_PROCEED', 'SAFE_BROWSING_RESPONSE_PROCEED');
+  static const SAFE_BROWSING_RESPONSE_PROCEED =
+      WebViewFeature._internal('SAFE_BROWSING_RESPONSE_PROCEED', 'SAFE_BROWSING_RESPONSE_PROCEED');
 
   ///
   static const SAFE_BROWSING_RESPONSE_SHOW_INTERSTITIAL =
-      WebViewFeature._internal('SAFE_BROWSING_RESPONSE_SHOW_INTERSTITIAL',
-          'SAFE_BROWSING_RESPONSE_SHOW_INTERSTITIAL');
+      WebViewFeature._internal('SAFE_BROWSING_RESPONSE_SHOW_INTERSTITIAL', 'SAFE_BROWSING_RESPONSE_SHOW_INTERSTITIAL');
 
   ///Use [SAFE_BROWSING_ALLOWLIST] instead.
-  static const SAFE_BROWSING_WHITELIST = WebViewFeature._internal(
-      'SAFE_BROWSING_WHITELIST', 'SAFE_BROWSING_WHITELIST');
+  static const SAFE_BROWSING_WHITELIST = WebViewFeature._internal('SAFE_BROWSING_WHITELIST', 'SAFE_BROWSING_WHITELIST');
 
   ///Feature for [isFeatureSupported]. This feature covers [ServiceWorkerController].
-  static const SERVICE_WORKER_BASIC_USAGE = WebViewFeature._internal(
-      'SERVICE_WORKER_BASIC_USAGE', 'SERVICE_WORKER_BASIC_USAGE');
+  static const SERVICE_WORKER_BASIC_USAGE =
+      WebViewFeature._internal('SERVICE_WORKER_BASIC_USAGE', 'SERVICE_WORKER_BASIC_USAGE');
 
   ///Feature for [isFeatureSupported]. This feature covers [ServiceWorkerController.setBlockNetworkLoads] and [ServiceWorkerController.getBlockNetworkLoads].
-  static const SERVICE_WORKER_BLOCK_NETWORK_LOADS = WebViewFeature._internal(
-      'SERVICE_WORKER_BLOCK_NETWORK_LOADS',
-      'SERVICE_WORKER_BLOCK_NETWORK_LOADS');
+  static const SERVICE_WORKER_BLOCK_NETWORK_LOADS =
+      WebViewFeature._internal('SERVICE_WORKER_BLOCK_NETWORK_LOADS', 'SERVICE_WORKER_BLOCK_NETWORK_LOADS');
 
   ///Feature for [isFeatureSupported]. This feature covers [ServiceWorkerController.setCacheMode] and [ServiceWorkerController.getCacheMode].
-  static const SERVICE_WORKER_CACHE_MODE = WebViewFeature._internal(
-      'SERVICE_WORKER_CACHE_MODE', 'SERVICE_WORKER_CACHE_MODE');
+  static const SERVICE_WORKER_CACHE_MODE =
+      WebViewFeature._internal('SERVICE_WORKER_CACHE_MODE', 'SERVICE_WORKER_CACHE_MODE');
 
   ///Feature for [isFeatureSupported]. This feature covers [ServiceWorkerController.setAllowContentAccess] and [ServiceWorkerController.getAllowContentAccess].
-  static const SERVICE_WORKER_CONTENT_ACCESS = WebViewFeature._internal(
-      'SERVICE_WORKER_CONTENT_ACCESS', 'SERVICE_WORKER_CONTENT_ACCESS');
+  static const SERVICE_WORKER_CONTENT_ACCESS =
+      WebViewFeature._internal('SERVICE_WORKER_CONTENT_ACCESS', 'SERVICE_WORKER_CONTENT_ACCESS');
 
   ///Feature for [isFeatureSupported]. This feature covers [ServiceWorkerController.setAllowFileAccess] and [ServiceWorkerController.getAllowFileAccess].
-  static const SERVICE_WORKER_FILE_ACCESS = WebViewFeature._internal(
-      'SERVICE_WORKER_FILE_ACCESS', 'SERVICE_WORKER_FILE_ACCESS');
+  static const SERVICE_WORKER_FILE_ACCESS =
+      WebViewFeature._internal('SERVICE_WORKER_FILE_ACCESS', 'SERVICE_WORKER_FILE_ACCESS');
 
   ///Feature for [isFeatureSupported]. This feature covers [ServiceWorkerClient.shouldInterceptRequest].
   static const SERVICE_WORKER_SHOULD_INTERCEPT_REQUEST =
-      WebViewFeature._internal('SERVICE_WORKER_SHOULD_INTERCEPT_REQUEST',
-          'SERVICE_WORKER_SHOULD_INTERCEPT_REQUEST');
+      WebViewFeature._internal('SERVICE_WORKER_SHOULD_INTERCEPT_REQUEST', 'SERVICE_WORKER_SHOULD_INTERCEPT_REQUEST');
 
   ///
-  static const SHOULD_OVERRIDE_WITH_REDIRECTS = WebViewFeature._internal(
-      'SHOULD_OVERRIDE_WITH_REDIRECTS', 'SHOULD_OVERRIDE_WITH_REDIRECTS');
+  static const SHOULD_OVERRIDE_WITH_REDIRECTS =
+      WebViewFeature._internal('SHOULD_OVERRIDE_WITH_REDIRECTS', 'SHOULD_OVERRIDE_WITH_REDIRECTS');
 
   ///Feature for [isStartupFeatureSupported]. This feature covers [ProcessGlobalConfigSettings.dataDirectorySuffix].
-  static const STARTUP_FEATURE_SET_DATA_DIRECTORY_SUFFIX =
-      WebViewFeature._internal('STARTUP_FEATURE_SET_DATA_DIRECTORY_SUFFIX',
-          'STARTUP_FEATURE_SET_DATA_DIRECTORY_SUFFIX');
+  static const STARTUP_FEATURE_SET_DATA_DIRECTORY_SUFFIX = WebViewFeature._internal(
+      'STARTUP_FEATURE_SET_DATA_DIRECTORY_SUFFIX', 'STARTUP_FEATURE_SET_DATA_DIRECTORY_SUFFIX');
 
   ///Feature for [isStartupFeatureSupported]. This feature covers [ProcessGlobalConfigSettings.directoryBasePaths].
   static const STARTUP_FEATURE_SET_DIRECTORY_BASE_PATHS =
-      WebViewFeature._internal('STARTUP_FEATURE_SET_DIRECTORY_BASE_PATHS',
-          'STARTUP_FEATURE_SET_DIRECTORY_BASE_PATHS');
+      WebViewFeature._internal('STARTUP_FEATURE_SET_DIRECTORY_BASE_PATHS', 'STARTUP_FEATURE_SET_DIRECTORY_BASE_PATHS');
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewController.startSafeBrowsing].
-  static const START_SAFE_BROWSING =
-      WebViewFeature._internal('START_SAFE_BROWSING', 'START_SAFE_BROWSING');
-
-  ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewSettings.willSuppressErrorPage].
-  static const SUPPRESS_ERROR_PAGE =
-      WebViewFeature._internal('SUPPRESS_ERROR_PAGE', 'SUPPRESS_ERROR_PAGE');
+  static const START_SAFE_BROWSING = WebViewFeature._internal('START_SAFE_BROWSING', 'START_SAFE_BROWSING');
 
   ///
-  static const TRACING_CONTROLLER_BASIC_USAGE = WebViewFeature._internal(
-      'TRACING_CONTROLLER_BASIC_USAGE', 'TRACING_CONTROLLER_BASIC_USAGE');
+  static const TRACING_CONTROLLER_BASIC_USAGE =
+      WebViewFeature._internal('TRACING_CONTROLLER_BASIC_USAGE', 'TRACING_CONTROLLER_BASIC_USAGE');
 
   ///
-  static const VISUAL_STATE_CALLBACK = WebViewFeature._internal(
-      'VISUAL_STATE_CALLBACK', 'VISUAL_STATE_CALLBACK');
+  static const VISUAL_STATE_CALLBACK = WebViewFeature._internal('VISUAL_STATE_CALLBACK', 'VISUAL_STATE_CALLBACK');
 
   ///Feature for [isFeatureSupported]. This feature covers [WebMessagePort.postMessage] with `ArrayBuffer` type,
   ///[InAppWebViewController.postWebMessage] with `ArrayBuffer` type, and [JavaScriptReplyProxy.postMessage] with `ArrayBuffer` type.
-  static const WEB_MESSAGE_ARRAY_BUFFER = WebViewFeature._internal(
-      'WEB_MESSAGE_ARRAY_BUFFER', 'WEB_MESSAGE_ARRAY_BUFFER');
+  static const WEB_MESSAGE_ARRAY_BUFFER =
+      WebViewFeature._internal('WEB_MESSAGE_ARRAY_BUFFER', 'WEB_MESSAGE_ARRAY_BUFFER');
 
   ///
-  static const WEB_MESSAGE_CALLBACK_ON_MESSAGE = WebViewFeature._internal(
-      'WEB_MESSAGE_CALLBACK_ON_MESSAGE', 'WEB_MESSAGE_CALLBACK_ON_MESSAGE');
+  static const WEB_MESSAGE_CALLBACK_ON_MESSAGE =
+      WebViewFeature._internal('WEB_MESSAGE_CALLBACK_ON_MESSAGE', 'WEB_MESSAGE_CALLBACK_ON_MESSAGE');
 
   ///Feature for [isFeatureSupported]. This feature covers [WebMessageListener].
-  static const WEB_MESSAGE_LISTENER =
-      WebViewFeature._internal('WEB_MESSAGE_LISTENER', 'WEB_MESSAGE_LISTENER');
+  static const WEB_MESSAGE_LISTENER = WebViewFeature._internal('WEB_MESSAGE_LISTENER', 'WEB_MESSAGE_LISTENER');
 
   ///
-  static const WEB_MESSAGE_PORT_CLOSE = WebViewFeature._internal(
-      'WEB_MESSAGE_PORT_CLOSE', 'WEB_MESSAGE_PORT_CLOSE');
+  static const WEB_MESSAGE_PORT_CLOSE = WebViewFeature._internal('WEB_MESSAGE_PORT_CLOSE', 'WEB_MESSAGE_PORT_CLOSE');
 
   ///
-  static const WEB_MESSAGE_PORT_POST_MESSAGE = WebViewFeature._internal(
-      'WEB_MESSAGE_PORT_POST_MESSAGE', 'WEB_MESSAGE_PORT_POST_MESSAGE');
+  static const WEB_MESSAGE_PORT_POST_MESSAGE =
+      WebViewFeature._internal('WEB_MESSAGE_PORT_POST_MESSAGE', 'WEB_MESSAGE_PORT_POST_MESSAGE');
 
   ///
-  static const WEB_MESSAGE_PORT_SET_MESSAGE_CALLBACK = WebViewFeature._internal(
-      'WEB_MESSAGE_PORT_SET_MESSAGE_CALLBACK',
-      'WEB_MESSAGE_PORT_SET_MESSAGE_CALLBACK');
+  static const WEB_MESSAGE_PORT_SET_MESSAGE_CALLBACK =
+      WebViewFeature._internal('WEB_MESSAGE_PORT_SET_MESSAGE_CALLBACK', 'WEB_MESSAGE_PORT_SET_MESSAGE_CALLBACK');
 
   ///
-  static const WEB_RESOURCE_ERROR_GET_CODE = WebViewFeature._internal(
-      'WEB_RESOURCE_ERROR_GET_CODE', 'WEB_RESOURCE_ERROR_GET_CODE');
+  static const WEB_RESOURCE_ERROR_GET_CODE =
+      WebViewFeature._internal('WEB_RESOURCE_ERROR_GET_CODE', 'WEB_RESOURCE_ERROR_GET_CODE');
 
   ///
-  static const WEB_RESOURCE_ERROR_GET_DESCRIPTION = WebViewFeature._internal(
-      'WEB_RESOURCE_ERROR_GET_DESCRIPTION',
-      'WEB_RESOURCE_ERROR_GET_DESCRIPTION');
+  static const WEB_RESOURCE_ERROR_GET_DESCRIPTION =
+      WebViewFeature._internal('WEB_RESOURCE_ERROR_GET_DESCRIPTION', 'WEB_RESOURCE_ERROR_GET_DESCRIPTION');
 
   ///
-  static const WEB_RESOURCE_REQUEST_IS_REDIRECT = WebViewFeature._internal(
-      'WEB_RESOURCE_REQUEST_IS_REDIRECT', 'WEB_RESOURCE_REQUEST_IS_REDIRECT');
+  static const WEB_RESOURCE_REQUEST_IS_REDIRECT =
+      WebViewFeature._internal('WEB_RESOURCE_REQUEST_IS_REDIRECT', 'WEB_RESOURCE_REQUEST_IS_REDIRECT');
 
   ///
-  static const WEB_VIEW_RENDERER_CLIENT_BASIC_USAGE = WebViewFeature._internal(
-      'WEB_VIEW_RENDERER_CLIENT_BASIC_USAGE',
-      'WEB_VIEW_RENDERER_CLIENT_BASIC_USAGE');
+  static const WEB_VIEW_RENDERER_CLIENT_BASIC_USAGE =
+      WebViewFeature._internal('WEB_VIEW_RENDERER_CLIENT_BASIC_USAGE', 'WEB_VIEW_RENDERER_CLIENT_BASIC_USAGE');
 
   ///
-  static const WEB_VIEW_RENDERER_TERMINATE = WebViewFeature._internal(
-      'WEB_VIEW_RENDERER_TERMINATE', 'WEB_VIEW_RENDERER_TERMINATE');
+  static const WEB_VIEW_RENDERER_TERMINATE =
+      WebViewFeature._internal('WEB_VIEW_RENDERER_TERMINATE', 'WEB_VIEW_RENDERER_TERMINATE');
 
   ///Set of all values of [WebViewFeature].
   static final Set<WebViewFeature> values = [
@@ -275,7 +238,6 @@ class WebViewFeature {
     WebViewFeature.STARTUP_FEATURE_SET_DATA_DIRECTORY_SUFFIX,
     WebViewFeature.STARTUP_FEATURE_SET_DIRECTORY_BASE_PATHS,
     WebViewFeature.START_SAFE_BROWSING,
-    WebViewFeature.SUPPRESS_ERROR_PAGE,
     WebViewFeature.TRACING_CONTROLLER_BASIC_USAGE,
     WebViewFeature.VISUAL_STATE_CALLBACK,
     WebViewFeature.WEB_MESSAGE_ARRAY_BUFFER,
@@ -295,8 +257,7 @@ class WebViewFeature {
   static WebViewFeature? fromValue(String? value) {
     if (value != null) {
       try {
-        return WebViewFeature.values
-            .firstWhere((element) => element.toValue() == value);
+        return WebViewFeature.values.firstWhere((element) => element.toValue() == value);
       } catch (e) {
         return null;
       }
@@ -308,8 +269,7 @@ class WebViewFeature {
   static WebViewFeature? fromNativeValue(String? value) {
     if (value != null) {
       try {
-        return WebViewFeature.values
-            .firstWhere((element) => element.toNativeValue() == value);
+        return WebViewFeature.values.firstWhere((element) => element.toNativeValue() == value);
       } catch (e) {
         return null;
       }
@@ -322,8 +282,7 @@ class WebViewFeature {
       PlatformWebViewFeature.static().isFeatureSupported(feature);
 
   ///{@macro flutter_inappwebview_platform_interface.PlatformWebViewFeature.isStartupFeatureSupported}
-  static Future<bool> isStartupFeatureSupported(
-          WebViewFeature startupFeature) =>
+  static Future<bool> isStartupFeatureSupported(WebViewFeature startupFeature) =>
       PlatformWebViewFeature.static().isStartupFeatureSupported(startupFeature);
 
   ///Gets [String] value.
@@ -352,207 +311,176 @@ class AndroidWebViewFeature {
   final String _nativeValue;
   const AndroidWebViewFeature._internal(this._value, this._nativeValue);
 // ignore: unused_element
-  factory AndroidWebViewFeature._internalMultiPlatform(
-          String value, Function nativeValue) =>
+  factory AndroidWebViewFeature._internalMultiPlatform(String value, Function nativeValue) =>
       AndroidWebViewFeature._internal(value, nativeValue());
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewSettings.algorithmicDarkeningAllowed].
-  static const ALGORITHMIC_DARKENING = AndroidWebViewFeature._internal(
-      'ALGORITHMIC_DARKENING', 'ALGORITHMIC_DARKENING');
+  static const ALGORITHMIC_DARKENING =
+      AndroidWebViewFeature._internal('ALGORITHMIC_DARKENING', 'ALGORITHMIC_DARKENING');
 
   ///
-  static const CREATE_WEB_MESSAGE_CHANNEL = AndroidWebViewFeature._internal(
-      'CREATE_WEB_MESSAGE_CHANNEL', 'CREATE_WEB_MESSAGE_CHANNEL');
+  static const CREATE_WEB_MESSAGE_CHANNEL =
+      AndroidWebViewFeature._internal('CREATE_WEB_MESSAGE_CHANNEL', 'CREATE_WEB_MESSAGE_CHANNEL');
 
   ///
   static const DISABLED_ACTION_MODE_MENU_ITEMS =
-      AndroidWebViewFeature._internal(
-          'DISABLED_ACTION_MODE_MENU_ITEMS', 'DISABLED_ACTION_MODE_MENU_ITEMS');
+      AndroidWebViewFeature._internal('DISABLED_ACTION_MODE_MENU_ITEMS', 'DISABLED_ACTION_MODE_MENU_ITEMS');
 
   ///Feature for [isFeatureSupported]. This feature covers [UserScriptInjectionTime.AT_DOCUMENT_START].
-  static const DOCUMENT_START_SCRIPT = AndroidWebViewFeature._internal(
-      'DOCUMENT_START_SCRIPT', 'DOCUMENT_START_SCRIPT');
+  static const DOCUMENT_START_SCRIPT =
+      AndroidWebViewFeature._internal('DOCUMENT_START_SCRIPT', 'DOCUMENT_START_SCRIPT');
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewSettings.enterpriseAuthenticationAppLinkPolicyEnabled].
-  static const ENTERPRISE_AUTHENTICATION_APP_LINK_POLICY =
-      AndroidWebViewFeature._internal(
-          'ENTERPRISE_AUTHENTICATION_APP_LINK_POLICY',
-          'ENTERPRISE_AUTHENTICATION_APP_LINK_POLICY');
+  static const ENTERPRISE_AUTHENTICATION_APP_LINK_POLICY = AndroidWebViewFeature._internal(
+      'ENTERPRISE_AUTHENTICATION_APP_LINK_POLICY', 'ENTERPRISE_AUTHENTICATION_APP_LINK_POLICY');
 
   ///
-  static const FORCE_DARK =
-      AndroidWebViewFeature._internal('FORCE_DARK', 'FORCE_DARK');
+  static const FORCE_DARK = AndroidWebViewFeature._internal('FORCE_DARK', 'FORCE_DARK');
 
   ///
-  static const FORCE_DARK_STRATEGY = AndroidWebViewFeature._internal(
-      'FORCE_DARK_STRATEGY', 'FORCE_DARK_STRATEGY');
+  static const FORCE_DARK_STRATEGY = AndroidWebViewFeature._internal('FORCE_DARK_STRATEGY', 'FORCE_DARK_STRATEGY');
 
   ///
-  static const GET_WEB_CHROME_CLIENT = AndroidWebViewFeature._internal(
-      'GET_WEB_CHROME_CLIENT', 'GET_WEB_CHROME_CLIENT');
+  static const GET_WEB_CHROME_CLIENT =
+      AndroidWebViewFeature._internal('GET_WEB_CHROME_CLIENT', 'GET_WEB_CHROME_CLIENT');
 
   ///
-  static const GET_WEB_VIEW_CLIENT = AndroidWebViewFeature._internal(
-      'GET_WEB_VIEW_CLIENT', 'GET_WEB_VIEW_CLIENT');
+  static const GET_WEB_VIEW_CLIENT = AndroidWebViewFeature._internal('GET_WEB_VIEW_CLIENT', 'GET_WEB_VIEW_CLIENT');
 
   ///
-  static const GET_WEB_VIEW_RENDERER = AndroidWebViewFeature._internal(
-      'GET_WEB_VIEW_RENDERER', 'GET_WEB_VIEW_RENDERER');
+  static const GET_WEB_VIEW_RENDERER =
+      AndroidWebViewFeature._internal('GET_WEB_VIEW_RENDERER', 'GET_WEB_VIEW_RENDERER');
 
   ///
-  static const MULTI_PROCESS =
-      AndroidWebViewFeature._internal('MULTI_PROCESS', 'MULTI_PROCESS');
+  static const MULTI_PROCESS = AndroidWebViewFeature._internal('MULTI_PROCESS', 'MULTI_PROCESS');
 
   ///
-  static const OFF_SCREEN_PRERASTER = AndroidWebViewFeature._internal(
-      'OFF_SCREEN_PRERASTER', 'OFF_SCREEN_PRERASTER');
+  static const OFF_SCREEN_PRERASTER = AndroidWebViewFeature._internal('OFF_SCREEN_PRERASTER', 'OFF_SCREEN_PRERASTER');
 
   ///
-  static const POST_WEB_MESSAGE =
-      AndroidWebViewFeature._internal('POST_WEB_MESSAGE', 'POST_WEB_MESSAGE');
+  static const POST_WEB_MESSAGE = AndroidWebViewFeature._internal('POST_WEB_MESSAGE', 'POST_WEB_MESSAGE');
 
   ///
-  static const PROXY_OVERRIDE =
-      AndroidWebViewFeature._internal('PROXY_OVERRIDE', 'PROXY_OVERRIDE');
+  static const PROXY_OVERRIDE = AndroidWebViewFeature._internal('PROXY_OVERRIDE', 'PROXY_OVERRIDE');
 
   ///
-  static const RECEIVE_HTTP_ERROR = AndroidWebViewFeature._internal(
-      'RECEIVE_HTTP_ERROR', 'RECEIVE_HTTP_ERROR');
+  static const RECEIVE_HTTP_ERROR = AndroidWebViewFeature._internal('RECEIVE_HTTP_ERROR', 'RECEIVE_HTTP_ERROR');
 
   ///
-  static const RECEIVE_WEB_RESOURCE_ERROR = AndroidWebViewFeature._internal(
-      'RECEIVE_WEB_RESOURCE_ERROR', 'RECEIVE_WEB_RESOURCE_ERROR');
+  static const RECEIVE_WEB_RESOURCE_ERROR =
+      AndroidWebViewFeature._internal('RECEIVE_WEB_RESOURCE_ERROR', 'RECEIVE_WEB_RESOURCE_ERROR');
 
   ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewSettings.requestedWithHeaderMode].
-  static const REQUESTED_WITH_HEADER_CONTROL = AndroidWebViewFeature._internal(
-      'REQUESTED_WITH_HEADER_CONTROL', 'REQUESTED_WITH_HEADER_CONTROL');
+  static const REQUESTED_WITH_HEADER_CONTROL =
+      AndroidWebViewFeature._internal('REQUESTED_WITH_HEADER_CONTROL', 'REQUESTED_WITH_HEADER_CONTROL');
 
   ///
-  static const SAFE_BROWSING_ALLOWLIST = AndroidWebViewFeature._internal(
-      'SAFE_BROWSING_ALLOWLIST', 'SAFE_BROWSING_ALLOWLIST');
+  static const SAFE_BROWSING_ALLOWLIST =
+      AndroidWebViewFeature._internal('SAFE_BROWSING_ALLOWLIST', 'SAFE_BROWSING_ALLOWLIST');
 
   ///
-  static const SAFE_BROWSING_ENABLE = AndroidWebViewFeature._internal(
-      'SAFE_BROWSING_ENABLE', 'SAFE_BROWSING_ENABLE');
+  static const SAFE_BROWSING_ENABLE = AndroidWebViewFeature._internal('SAFE_BROWSING_ENABLE', 'SAFE_BROWSING_ENABLE');
 
   ///
-  static const SAFE_BROWSING_HIT =
-      AndroidWebViewFeature._internal('SAFE_BROWSING_HIT', 'SAFE_BROWSING_HIT');
+  static const SAFE_BROWSING_HIT = AndroidWebViewFeature._internal('SAFE_BROWSING_HIT', 'SAFE_BROWSING_HIT');
 
   ///
   static const SAFE_BROWSING_PRIVACY_POLICY_URL =
-      AndroidWebViewFeature._internal('SAFE_BROWSING_PRIVACY_POLICY_URL',
-          'SAFE_BROWSING_PRIVACY_POLICY_URL');
+      AndroidWebViewFeature._internal('SAFE_BROWSING_PRIVACY_POLICY_URL', 'SAFE_BROWSING_PRIVACY_POLICY_URL');
 
   ///
   static const SAFE_BROWSING_RESPONSE_BACK_TO_SAFETY =
-      AndroidWebViewFeature._internal('SAFE_BROWSING_RESPONSE_BACK_TO_SAFETY',
-          'SAFE_BROWSING_RESPONSE_BACK_TO_SAFETY');
+      AndroidWebViewFeature._internal('SAFE_BROWSING_RESPONSE_BACK_TO_SAFETY', 'SAFE_BROWSING_RESPONSE_BACK_TO_SAFETY');
 
   ///
-  static const SAFE_BROWSING_RESPONSE_PROCEED = AndroidWebViewFeature._internal(
-      'SAFE_BROWSING_RESPONSE_PROCEED', 'SAFE_BROWSING_RESPONSE_PROCEED');
+  static const SAFE_BROWSING_RESPONSE_PROCEED =
+      AndroidWebViewFeature._internal('SAFE_BROWSING_RESPONSE_PROCEED', 'SAFE_BROWSING_RESPONSE_PROCEED');
 
   ///
-  static const SAFE_BROWSING_RESPONSE_SHOW_INTERSTITIAL =
-      AndroidWebViewFeature._internal(
-          'SAFE_BROWSING_RESPONSE_SHOW_INTERSTITIAL',
-          'SAFE_BROWSING_RESPONSE_SHOW_INTERSTITIAL');
+  static const SAFE_BROWSING_RESPONSE_SHOW_INTERSTITIAL = AndroidWebViewFeature._internal(
+      'SAFE_BROWSING_RESPONSE_SHOW_INTERSTITIAL', 'SAFE_BROWSING_RESPONSE_SHOW_INTERSTITIAL');
 
   ///Use [SAFE_BROWSING_ALLOWLIST] instead.
-  static const SAFE_BROWSING_WHITELIST = AndroidWebViewFeature._internal(
-      'SAFE_BROWSING_WHITELIST', 'SAFE_BROWSING_WHITELIST');
+  static const SAFE_BROWSING_WHITELIST =
+      AndroidWebViewFeature._internal('SAFE_BROWSING_WHITELIST', 'SAFE_BROWSING_WHITELIST');
 
   ///
-  static const SERVICE_WORKER_BASIC_USAGE = AndroidWebViewFeature._internal(
-      'SERVICE_WORKER_BASIC_USAGE', 'SERVICE_WORKER_BASIC_USAGE');
+  static const SERVICE_WORKER_BASIC_USAGE =
+      AndroidWebViewFeature._internal('SERVICE_WORKER_BASIC_USAGE', 'SERVICE_WORKER_BASIC_USAGE');
 
   ///
   static const SERVICE_WORKER_BLOCK_NETWORK_LOADS =
-      AndroidWebViewFeature._internal('SERVICE_WORKER_BLOCK_NETWORK_LOADS',
-          'SERVICE_WORKER_BLOCK_NETWORK_LOADS');
+      AndroidWebViewFeature._internal('SERVICE_WORKER_BLOCK_NETWORK_LOADS', 'SERVICE_WORKER_BLOCK_NETWORK_LOADS');
 
   ///
-  static const SERVICE_WORKER_CACHE_MODE = AndroidWebViewFeature._internal(
-      'SERVICE_WORKER_CACHE_MODE', 'SERVICE_WORKER_CACHE_MODE');
+  static const SERVICE_WORKER_CACHE_MODE =
+      AndroidWebViewFeature._internal('SERVICE_WORKER_CACHE_MODE', 'SERVICE_WORKER_CACHE_MODE');
 
   ///
-  static const SERVICE_WORKER_CONTENT_ACCESS = AndroidWebViewFeature._internal(
-      'SERVICE_WORKER_CONTENT_ACCESS', 'SERVICE_WORKER_CONTENT_ACCESS');
+  static const SERVICE_WORKER_CONTENT_ACCESS =
+      AndroidWebViewFeature._internal('SERVICE_WORKER_CONTENT_ACCESS', 'SERVICE_WORKER_CONTENT_ACCESS');
 
   ///
-  static const SERVICE_WORKER_FILE_ACCESS = AndroidWebViewFeature._internal(
-      'SERVICE_WORKER_FILE_ACCESS', 'SERVICE_WORKER_FILE_ACCESS');
+  static const SERVICE_WORKER_FILE_ACCESS =
+      AndroidWebViewFeature._internal('SERVICE_WORKER_FILE_ACCESS', 'SERVICE_WORKER_FILE_ACCESS');
 
   ///
-  static const SERVICE_WORKER_SHOULD_INTERCEPT_REQUEST =
-      AndroidWebViewFeature._internal('SERVICE_WORKER_SHOULD_INTERCEPT_REQUEST',
-          'SERVICE_WORKER_SHOULD_INTERCEPT_REQUEST');
+  static const SERVICE_WORKER_SHOULD_INTERCEPT_REQUEST = AndroidWebViewFeature._internal(
+      'SERVICE_WORKER_SHOULD_INTERCEPT_REQUEST', 'SERVICE_WORKER_SHOULD_INTERCEPT_REQUEST');
 
   ///
-  static const SHOULD_OVERRIDE_WITH_REDIRECTS = AndroidWebViewFeature._internal(
-      'SHOULD_OVERRIDE_WITH_REDIRECTS', 'SHOULD_OVERRIDE_WITH_REDIRECTS');
+  static const SHOULD_OVERRIDE_WITH_REDIRECTS =
+      AndroidWebViewFeature._internal('SHOULD_OVERRIDE_WITH_REDIRECTS', 'SHOULD_OVERRIDE_WITH_REDIRECTS');
 
   ///
-  static const START_SAFE_BROWSING = AndroidWebViewFeature._internal(
-      'START_SAFE_BROWSING', 'START_SAFE_BROWSING');
-
-  ///Feature for [isFeatureSupported]. This feature covers [InAppWebViewSettings.willSuppressErrorPage].
-  static const SUPPRESS_ERROR_PAGE = AndroidWebViewFeature._internal(
-      'SUPPRESS_ERROR_PAGE', 'SUPPRESS_ERROR_PAGE');
+  static const START_SAFE_BROWSING = AndroidWebViewFeature._internal('START_SAFE_BROWSING', 'START_SAFE_BROWSING');
 
   ///
-  static const TRACING_CONTROLLER_BASIC_USAGE = AndroidWebViewFeature._internal(
-      'TRACING_CONTROLLER_BASIC_USAGE', 'TRACING_CONTROLLER_BASIC_USAGE');
+  static const TRACING_CONTROLLER_BASIC_USAGE =
+      AndroidWebViewFeature._internal('TRACING_CONTROLLER_BASIC_USAGE', 'TRACING_CONTROLLER_BASIC_USAGE');
 
   ///
-  static const VISUAL_STATE_CALLBACK = AndroidWebViewFeature._internal(
-      'VISUAL_STATE_CALLBACK', 'VISUAL_STATE_CALLBACK');
+  static const VISUAL_STATE_CALLBACK =
+      AndroidWebViewFeature._internal('VISUAL_STATE_CALLBACK', 'VISUAL_STATE_CALLBACK');
 
   ///
   static const WEB_MESSAGE_CALLBACK_ON_MESSAGE =
-      AndroidWebViewFeature._internal(
-          'WEB_MESSAGE_CALLBACK_ON_MESSAGE', 'WEB_MESSAGE_CALLBACK_ON_MESSAGE');
+      AndroidWebViewFeature._internal('WEB_MESSAGE_CALLBACK_ON_MESSAGE', 'WEB_MESSAGE_CALLBACK_ON_MESSAGE');
 
   ///
-  static const WEB_MESSAGE_LISTENER = AndroidWebViewFeature._internal(
-      'WEB_MESSAGE_LISTENER', 'WEB_MESSAGE_LISTENER');
+  static const WEB_MESSAGE_LISTENER = AndroidWebViewFeature._internal('WEB_MESSAGE_LISTENER', 'WEB_MESSAGE_LISTENER');
 
   ///
-  static const WEB_MESSAGE_PORT_CLOSE = AndroidWebViewFeature._internal(
-      'WEB_MESSAGE_PORT_CLOSE', 'WEB_MESSAGE_PORT_CLOSE');
+  static const WEB_MESSAGE_PORT_CLOSE =
+      AndroidWebViewFeature._internal('WEB_MESSAGE_PORT_CLOSE', 'WEB_MESSAGE_PORT_CLOSE');
 
   ///
-  static const WEB_MESSAGE_PORT_POST_MESSAGE = AndroidWebViewFeature._internal(
-      'WEB_MESSAGE_PORT_POST_MESSAGE', 'WEB_MESSAGE_PORT_POST_MESSAGE');
+  static const WEB_MESSAGE_PORT_POST_MESSAGE =
+      AndroidWebViewFeature._internal('WEB_MESSAGE_PORT_POST_MESSAGE', 'WEB_MESSAGE_PORT_POST_MESSAGE');
 
   ///
   static const WEB_MESSAGE_PORT_SET_MESSAGE_CALLBACK =
-      AndroidWebViewFeature._internal('WEB_MESSAGE_PORT_SET_MESSAGE_CALLBACK',
-          'WEB_MESSAGE_PORT_SET_MESSAGE_CALLBACK');
+      AndroidWebViewFeature._internal('WEB_MESSAGE_PORT_SET_MESSAGE_CALLBACK', 'WEB_MESSAGE_PORT_SET_MESSAGE_CALLBACK');
 
   ///
-  static const WEB_RESOURCE_ERROR_GET_CODE = AndroidWebViewFeature._internal(
-      'WEB_RESOURCE_ERROR_GET_CODE', 'WEB_RESOURCE_ERROR_GET_CODE');
+  static const WEB_RESOURCE_ERROR_GET_CODE =
+      AndroidWebViewFeature._internal('WEB_RESOURCE_ERROR_GET_CODE', 'WEB_RESOURCE_ERROR_GET_CODE');
 
   ///
   static const WEB_RESOURCE_ERROR_GET_DESCRIPTION =
-      AndroidWebViewFeature._internal('WEB_RESOURCE_ERROR_GET_DESCRIPTION',
-          'WEB_RESOURCE_ERROR_GET_DESCRIPTION');
+      AndroidWebViewFeature._internal('WEB_RESOURCE_ERROR_GET_DESCRIPTION', 'WEB_RESOURCE_ERROR_GET_DESCRIPTION');
 
   ///
   static const WEB_RESOURCE_REQUEST_IS_REDIRECT =
-      AndroidWebViewFeature._internal('WEB_RESOURCE_REQUEST_IS_REDIRECT',
-          'WEB_RESOURCE_REQUEST_IS_REDIRECT');
+      AndroidWebViewFeature._internal('WEB_RESOURCE_REQUEST_IS_REDIRECT', 'WEB_RESOURCE_REQUEST_IS_REDIRECT');
 
   ///
   static const WEB_VIEW_RENDERER_CLIENT_BASIC_USAGE =
-      AndroidWebViewFeature._internal('WEB_VIEW_RENDERER_CLIENT_BASIC_USAGE',
-          'WEB_VIEW_RENDERER_CLIENT_BASIC_USAGE');
+      AndroidWebViewFeature._internal('WEB_VIEW_RENDERER_CLIENT_BASIC_USAGE', 'WEB_VIEW_RENDERER_CLIENT_BASIC_USAGE');
 
   ///
-  static const WEB_VIEW_RENDERER_TERMINATE = AndroidWebViewFeature._internal(
-      'WEB_VIEW_RENDERER_TERMINATE', 'WEB_VIEW_RENDERER_TERMINATE');
+  static const WEB_VIEW_RENDERER_TERMINATE =
+      AndroidWebViewFeature._internal('WEB_VIEW_RENDERER_TERMINATE', 'WEB_VIEW_RENDERER_TERMINATE');
 
   ///Set of all values of [AndroidWebViewFeature].
   static final Set<AndroidWebViewFeature> values = [
@@ -589,7 +517,6 @@ class AndroidWebViewFeature {
     AndroidWebViewFeature.SERVICE_WORKER_SHOULD_INTERCEPT_REQUEST,
     AndroidWebViewFeature.SHOULD_OVERRIDE_WITH_REDIRECTS,
     AndroidWebViewFeature.START_SAFE_BROWSING,
-    AndroidWebViewFeature.SUPPRESS_ERROR_PAGE,
     AndroidWebViewFeature.TRACING_CONTROLLER_BASIC_USAGE,
     AndroidWebViewFeature.VISUAL_STATE_CALLBACK,
     AndroidWebViewFeature.WEB_MESSAGE_CALLBACK_ON_MESSAGE,
@@ -608,8 +535,7 @@ class AndroidWebViewFeature {
   static AndroidWebViewFeature? fromValue(String? value) {
     if (value != null) {
       try {
-        return AndroidWebViewFeature.values
-            .firstWhere((element) => element.toValue() == value);
+        return AndroidWebViewFeature.values.firstWhere((element) => element.toValue() == value);
       } catch (e) {
         return null;
       }
@@ -621,8 +547,7 @@ class AndroidWebViewFeature {
   static AndroidWebViewFeature? fromNativeValue(String? value) {
     if (value != null) {
       try {
-        return AndroidWebViewFeature.values
-            .firstWhere((element) => element.toNativeValue() == value);
+        return AndroidWebViewFeature.values.firstWhere((element) => element.toNativeValue() == value);
       } catch (e) {
         return null;
       }
@@ -636,8 +561,7 @@ class AndroidWebViewFeature {
   ///
   ///**Official Android API**: https://developer.android.com/reference/androidx/webkit/WebViewFeature#isFeatureSupported(java.lang.String)
   static Future<bool> isFeatureSupported(AndroidWebViewFeature feature) =>
-      PlatformWebViewFeature.static().isFeatureSupported(
-          WebViewFeature.fromNativeValue(feature.toNativeValue())!);
+      PlatformWebViewFeature.static().isFeatureSupported(WebViewFeature.fromNativeValue(feature.toNativeValue())!);
 
   ///Gets [String] value.
   String toValue() => _value;


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #2150

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->

## Testing and Review Notes

The SUPPRESS_ERROR_PAGE feature was discontinued according to [this](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:webkit/webkit/src/main/java/androidx/webkit/WebViewFeature.java;bpv=1;bpt=0;drc=071a5be0e7583c5ded85015ff94dc2ab7a7f0d62;dlc=bf75ca82f3a2182d583436a85f466396cf2f4f72) change in Webkit's WebViewFeature.java.

The recent upgrade of webkit to 1.10.0 in webview_flutter_android causes the webview to be null.

This suppresses references to SUPPRESS_ERROR_PAGE.




