### PR TITLE
Enable CORS for DefaultInAppLocalhostServer

### DIFF
--- a/flutter_inappwebview_platform_interface/lib/src/in_app_localhost_server.dart
+++ b/flutter_inappwebview_platform_interface/lib/src/in_app_localhost_server.dart
@@ -83,6 +83,8 @@ class DefaultInAppLocalhostServer extends PlatformInAppLocalhostServer {
         this._server = server;
 
         server.listen((HttpRequest request) async {
+          request.response.headers.add('Access-Control-Allow-Origin', '*');
+          
           Uint8List body = Uint8List(0);
 
           var path = request.requestedUri.path;


### PR DESCRIPTION
Current implementation does not allow running multiple local servers communication with each other.

This addition adds the missing CORS header. As the servers bind to 127 anyway it should be no security issue.

My use case requires two InAppLocalhostServer:

- 8080 - three.js app bundled in /assets - requesting models and sprites from localhost:8888
- 8888 - models and sprites placed in Flutter Document dir

Without CORS the app running at 8080 is not allowed to get files from 8888.