### PR TITLE
fix: Add missing proguard rule for BackEvent

### DIFF
--- a/flutter_inappwebview_android/CHANGELOG.md
+++ b/flutter_inappwebview_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.14
+
+- Fixed an issue with Android release mode compilation on Flutter 3.22
+
 ## 1.0.13
 
 - Fixed "Android emulator using API 34 fails to draw on resume sometimes" [#1981](https://github.com/pichillilorenzo/flutter_inappwebview/issues/1981)

--- a/flutter_inappwebview_android/android/proguard-rules.pro
+++ b/flutter_inappwebview_android/android/proguard-rules.pro
@@ -15,3 +15,6 @@
      private *;
 }
 -keep class com.pichillilorenzo.flutter_inappwebview_android.** { *; }
+
+# Required for compiling on Flutter 3.22.x
+-dontwarn android.window.BackEvent

--- a/flutter_inappwebview_android/pubspec.yaml
+++ b/flutter_inappwebview_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_inappwebview_android
 description: Android implementation of the flutter_inappwebview plugin.
-version: 1.0.13
+version: 1.0.14
 homepage: https://inappwebview.dev/
 repository: https://github.com/pichillilorenzo/flutter_inappwebview/tree/master/flutter_inappwebview_android
 issue_tracker: https://github.com/pichillilorenzo/flutter_inappwebview/issues


### PR DESCRIPTION
## Connection with issue(s)

Fixes https://github.com/pichillilorenzo/flutter_inappwebview/issues/2178

Related: https://github.com/pichillilorenzo/flutter_inappwebview/pull/2189,
but that PR makes changes to all sub-packages.

Instead _this_ PR makes a hotfix-only change and version bump for `flutter_inappwebview_android`. Since `flutter_inappwebview` specifies `flutter_inappwebview_android: ^1.0.12` as dependency constraint, users should be able to get this fix on the next `flutter pub get` when this fix is published.

## Testing and Review Notes

Building the `flutter_inappwebview` example app as an APK in release mode, on Flutter 3.22.1 should work.

## Screenshots or Videos

N/A

## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] request the "UX" team perform a design review (if/when applicable)
