### PR TITLE
Add null check for readyState in InterceptAjaxRequestJS

### DIFF
--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/plugin_scripts_js/InterceptAjaxRequestJS.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/plugin_scripts_js/InterceptAjaxRequestJS.java
@@ -140,6 +140,9 @@ public class InterceptAjaxRequestJS {
           "        this._flutter_inappwebview_already_onreadystatechange_wrapped = true;" +
           "        var onreadystatechange = this.onreadystatechange;" +
           "        this.onreadystatechange = function() {" +
+          "          if (this.readyState != XMLHttpRequest.DONE) {" +
+          "            return;" +
+          "          }" +
           "          var w = (window.top == null || window.top === window) ? window : window.top;" +
           "          if (w." + FLAG_VARIABLE_FOR_SHOULD_INTERCEPT_AJAX_REQUEST_JS_SOURCE + " == null || w." + FLAG_VARIABLE_FOR_SHOULD_INTERCEPT_AJAX_REQUEST_JS_SOURCE + " == true) {" +
           "            var headers = this.getAllResponseHeaders();" +

--- a/flutter_inappwebview_ios/ios/Classes/PluginScriptsJS/InterceptAjaxRequestJS.swift
+++ b/flutter_inappwebview_ios/ios/Classes/PluginScriptsJS/InterceptAjaxRequestJS.swift
@@ -140,6 +140,9 @@ let INTERCEPT_AJAX_REQUEST_JS_SOURCE = """
         this._flutter_inappwebview_already_onreadystatechange_wrapped = true;
         var onreadystatechange = this.onreadystatechange;
         this.onreadystatechange = function() {
+          if (this.readyState != XMLHttpRequest.DONE) {
+            return;
+          }
           if (\(FLAG_VARIABLE_FOR_SHOULD_INTERCEPT_AJAX_REQUEST_JS_SOURCE) == null || \(FLAG_VARIABLE_FOR_SHOULD_INTERCEPT_AJAX_REQUEST_JS_SOURCE) == true) {
             var headers = this.getAllResponseHeaders();
             var responseHeaders = {};

--- a/flutter_inappwebview_macos/macos/Classes/PluginScriptsJS/InterceptAjaxRequestJS.swift
+++ b/flutter_inappwebview_macos/macos/Classes/PluginScriptsJS/InterceptAjaxRequestJS.swift
@@ -141,6 +141,9 @@ let INTERCEPT_AJAX_REQUEST_JS_SOURCE = """
         this._flutter_inappwebview_already_onreadystatechange_wrapped = true;
         var onreadystatechange = this.onreadystatechange;
         this.onreadystatechange = function() {
+          if (this.readyState != XMLHttpRequest.DONE) {
+            return;
+          }
           if (\(FLAG_VARIABLE_FOR_SHOULD_INTERCEPT_AJAX_REQUEST_JS_SOURCE) == null || \(FLAG_VARIABLE_FOR_SHOULD_INTERCEPT_AJAX_REQUEST_JS_SOURCE) == true) {
             var headers = this.getAllResponseHeaders();
             var responseHeaders = {};


### PR DESCRIPTION
Add null check for readyState in InterceptAjaxRequestJS to skip events that are not done.

## Connection with issue(s)

Resolve issue #2197 

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->

Connected to #404 

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->

## Testing and Review Notes

<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->
To fix that issue, I've referenced [this URL.](https://stackoverflow.com/questions/53857600/xmlhttprequest-responsetext-is-null)

## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [X] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable)
