### PR TITLE
fixed flutter 3.22.2 compatibility issue

### DIFF
--- a/flutter_inappwebview_android/android/proguard-rules.pro
+++ b/flutter_inappwebview_android/android/proguard-rules.pro
@@ -15,3 +15,4 @@
      private *;
 }
 -keep class com.pichillilorenzo.flutter_inappwebview_android.** { *; }
+-dontwarn android.window.BackEvent


### PR DESCRIPTION
Upon upgrading to flutter 3.22.2, the app is not being built successfully due to the missing proguard rule in flutter_android_inappwebview.