### PR TITLE
Android: implemented PlatformPrintJobController.onComplete

### DIFF
--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/print_job/PrintJobChannelDelegate.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/print_job/PrintJobChannelDelegate.java
@@ -62,6 +62,10 @@ public class PrintJobChannelDelegate extends ChannelDelegateImpl {
     }
   }
 
+  public void onComplete() {
+    getChannel().invokeMethod("onComplete", null);
+  }
+
   @Override
   public void dispose() {
     super.dispose();

--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/print_job/PrintJobController.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/print_job/PrintJobController.java
@@ -28,16 +28,19 @@ public class PrintJobController implements Disposable  {
   @Nullable
   public PrintJobSettings settings;
 
-  public PrintJobController(@NonNull String id, @NonNull android.print.PrintJob job,
-                            @Nullable PrintJobSettings settings, @NonNull InAppWebViewFlutterPlugin plugin) {
+  public PrintJobController(@NonNull String id, @Nullable PrintJobSettings settings,
+                            @NonNull InAppWebViewFlutterPlugin plugin) {
     this.id = id;
     this.plugin = plugin;
-    this.job = job;
     this.settings = settings;
     final MethodChannel channel = new MethodChannel(plugin.messenger, METHOD_CHANNEL_NAME_PREFIX + id);
     this.channelDelegate = new PrintJobChannelDelegate(this, channel);
   }
-  
+
+  public void setJob(@Nullable android.print.PrintJob job) {
+    this.job = job;
+  }
+
   public void cancel() {
     if (this.job != null) {
       this.job.cancel();
@@ -92,5 +95,9 @@ public class PrintJobController implements Disposable  {
       job = null;
     }
     plugin = null;
+  }
+
+  public void onComplete() {
+    if (channelDelegate != null) channelDelegate.onComplete();
   }
 }

--- a/flutter_inappwebview_android/lib/src/print_job/print_job_controller.dart
+++ b/flutter_inappwebview_android/lib/src/print_job/print_job_controller.dart
@@ -43,6 +43,9 @@ class AndroidPrintJobController extends PlatformPrintJobController
 
   Future<dynamic> _handleMethod(MethodCall call) async {
     switch (call.method) {
+      case "onComplete":
+          onComplete?.call(true, null);
+        break;
       default:
         throw UnimplementedError("Unimplemented ${call.method} method");
     }

--- a/flutter_inappwebview_platform_interface/lib/src/print_job/platform_print_job_controller.dart
+++ b/flutter_inappwebview_platform_interface/lib/src/print_job/platform_print_job_controller.dart
@@ -73,6 +73,7 @@ abstract class PlatformPrintJobController extends PlatformInterface
   ///A completion handler used to handle the conclusion of the print job (for instance, to reset state) and to handle any errors encountered in printing.
   ///
   ///**Officially Supported Platforms/Implementations**:
+  ///- Android ([Official API - PrintDocumentAdapter.onFinish](https://developer.android.com/reference/android/print/PrintDocumentAdapter#onFinish()))
   ///- iOS ([Official API - UIPrintInteractionController.CompletionHandler](https://developer.apple.com/documentation/uikit/uiprintinteractioncontroller/completionhandler))
   ///- MacOS ([Official API - NSPrintOperation.runModal](https://developer.apple.com/documentation/appkit/nsprintoperation/1532065-runmodal))
   ///{@endtemplate}


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue:
Webview can only be disposed when printing job finished, this PR given a chance for listening when printing job get done on Android.

```dart
printJobController.printCurrentPage(settings: PrintJobSettings(handledByClient: true));
final completer = Completer();
printJobController.onComplete = (completed, error) async {
    printJobController.dispose();
    completer.complete();
};
await completer.future;
// Webview can only be disposed when printing job finished
headlessInAppWebviewController.dispose();
```

## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable)
