### PR TITLE
Fixes CVE-2020-6563

### DIFF
--- a/flutter_inappwebview_android/CHANGELOG.md
+++ b/flutter_inappwebview_android/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Updated android native `compileOptions` to `JavaVersion.VERSION_17`
 - Implemented `saveState`, `restoreState` InAppWebViewController methods
 - Implemented `onShowFileChooser` WebView event
+- Fixed CVE-2020-6563: reject `file://` URIs that resolve into the app's private data directory when a malicious file picker hands them back via the `<input type="file">` chooser (thanks to [AlexV525](https://github.com/AlexV525))
 - Updated InAppBrowser toolbar top
 - Merged "Android: implemented PlatformPrintJobController.onComplete" [#2216](https://github.com/pichillilorenzo/flutter_inappwebview/pull/2216) (thanks to [Doflatango](https://github.com/Doflatango))
 - Fixed "When useShouldInterceptAjaxRequest is true, some ajax requests doesn't work" [#2197](https://github.com/pichillilorenzo/flutter_inappwebview/issues/2197)

--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/in_app_webview/InAppWebViewChromeClient.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/in_app_webview/InAppWebViewChromeClient.java
@@ -848,6 +848,22 @@ public class InAppWebViewChromeClient extends WebChromeClient implements PluginR
       return true;
     }
 
+    // Excludes intents who want to obtain sandbox files.
+    // Fixes CVE-2020-6563.
+    if (data != null && data.getData().getPath() != null) {
+      final String path = data.getData().getPath();
+      final File file = new File(path);
+      String normalized;
+      try {
+        normalized = file.getCanonicalPath();
+      } catch (IOException e) {
+        normalized = path;
+      }
+      if (normalized.startsWith("/data")) {
+        data.setData(Uri.EMPTY);
+      }
+    }
+
     // based off of which button was pressed, we get an activity result and a file
     // the camera activity doesn't properly return the filename* (I think?) so we use
     // this filename instead

--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/in_app_webview/InAppWebViewChromeClient.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/in_app_webview/InAppWebViewChromeClient.java
@@ -921,6 +921,12 @@ public class InAppWebViewChromeClient extends WebChromeClient implements PluginR
         Uri result = null;
         if (resultCode == RESULT_OK) {
           result = data != null ? data.getData() : getCapturedMediaFile();
+          // Reject file:// URIs that resolve into the app's private sandbox, which a
+          // malicious file picker can hand back to read files it cannot access itself.
+          // Fixes CVE-2020-6563.
+          if (isPrivateSandboxFileUri(result)) {
+            result = null;
+          }
         }
         if (filePathCallbackLegacy != null) {
           filePathCallbackLegacy.onReceiveValue(result);
@@ -940,7 +946,7 @@ public class InAppWebViewChromeClient extends WebChromeClient implements PluginR
     // we have one file selected
     if (data != null && data.getData() != null) {
       if (resultCode == RESULT_OK && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-        return WebChromeClient.FileChooserParams.parseResult(resultCode, data);
+        return filterSandboxFileUris(WebChromeClient.FileChooserParams.parseResult(resultCode, data));
       } else {
         return null;
       }
@@ -953,7 +959,7 @@ public class InAppWebViewChromeClient extends WebChromeClient implements PluginR
       for (int i = 0; i < numSelectedFiles; i++) {
         result[i] = data.getClipData().getItemAt(i).getUri();
       }
-      return result;
+      return filterSandboxFileUris(result);
     }
 
     // we have a captured image or video file
@@ -963,6 +969,76 @@ public class InAppWebViewChromeClient extends WebChromeClient implements PluginR
     }
 
     return null;
+  }
+
+  /**
+   * Returns {@code true} if the given {@code file://} URI resolves into the app's own
+   * private data directory. A malicious file picker can return such URIs so that the
+   * WebView host reads a sandbox file it has access to (but the picker does not) and
+   * hands its contents to the web page (CVE-2020-6563).
+   *
+   * <p>Legitimate picks are {@code content://} URIs, and camera captures use the app's
+   * own FileProvider {@code content://} URI (or external-storage {@code file://} URIs),
+   * none of which live under the private data dir, so normal selection and capture are
+   * unaffected.
+   *
+   * <p>{@code content://} URIs are intentionally out of scope: a legitimate content
+   * provider is the normal selection path, and validating it requires resolving the
+   * backing file rather than the URI path.
+   */
+  private boolean isPrivateSandboxFileUri(@Nullable Uri uri) {
+    if (uri == null || !"file".equals(uri.getScheme())) {
+      return false;
+    }
+    String path = uri.getPath();
+    if (path == null) {
+      return false;
+    }
+    final String normalized = canonicalizePath(path);
+
+    // Primary anchor: the app's own private data directory (e.g. /data/user/0/<package>).
+    final Activity activity = getActivity();
+    if (activity != null) {
+      final String dataDir = activity.getApplicationInfo().dataDir;
+      if (dataDir != null) {
+        String normalizedDataDir = canonicalizePath(dataDir);
+        String dirPrefix = normalizedDataDir.endsWith("/")
+                ? normalizedDataDir : normalizedDataDir + "/";
+        if (normalized.startsWith(dirPrefix)) {
+          return true;
+        }
+      }
+    }
+    // Defense-in-depth: legitimate pickers never return file:// URIs that resolve under
+    // /data, where every app sandbox lives.
+    return normalized.startsWith("/data/");
+  }
+
+  private static String canonicalizePath(@NonNull String path) {
+    try {
+      return new File(path).getCanonicalPath();
+    } catch (IOException e) {
+      return path;
+    }
+  }
+
+  /**
+   * Removes any {@code file://} URI that points into the app's private sandbox. Preserves
+   * {@code null}; returns {@code null} only when every URI was rejected so the chooser
+   * reports "no valid selection" instead of leaking the rejected entry.
+   */
+  @Nullable
+  private Uri[] filterSandboxFileUris(@Nullable Uri[] uris) {
+    if (uris == null) {
+      return null;
+    }
+    List<Uri> safe = new ArrayList<>();
+    for (Uri uri : uris) {
+      if (!isPrivateSandboxFileUri(uri)) {
+        safe.add(uri);
+      }
+    }
+    return safe.size() == uris.length ? uris : (safe.isEmpty() ? null : safe.toArray(new Uri[0]));
   }
 
   private boolean isFileNotEmpty(Uri uri) {


### PR DESCRIPTION
## Fixes CVE-2020-6563

> downstream https://github.com/AstroxNetwork/flutter_inappwebview/commit/f50270ff83526f3caa4361b9f7b63cb21bd5efe9

A malicious file picker (a third-party app that registers to handle the implicit file chooser intent from `<input type="file">`) can return a `file://` URI pointing into the **host app's own private data directory**. The WebView host can read that file (the picker itself cannot), so its contents get handed to the web page — an information disclosure.

This is exactly what the Android platform guidance on `WebChromeClient.FileChooserParams` warns about:

> **Your app should check the resultant Uris in `parseResult` before calling the `filePathCallback`.** … *WebView does not enforce any restrictions on the returned Uris. It is the app's responsibility to ensure that the untrusted source … has access [to] the Uris it has returned and that the Uris are not pointing to any sensitive data files.*

This PR implements that check.

## Approach

Filter the URIs returned from the file chooser in `InAppWebViewChromeClient` before invoking `filePathCallback` / `filePathCallbackLegacy`, rejecting any `file://` URI that resolves into the app's private sandbox:

- **Only `file://` URIs are inspected.** Legitimate picks are `content://`, and camera captures use the app's own FileProvider `content://` URI (or external-storage `file://`), so normal selection and capture are unaffected. This matches [OWASP MASTG-BEST-0057](https://mas.owasp.org/MASTG/best-practices/MASTG-BEST-0057/): *"Prefer `content://` URIs over `file://` URIs when processing externally supplied data."*
- **Primary anchor is `ApplicationInfo.dataDir`** (e.g. `/data/user/0/<package>`), with `/data/` as defense-in-depth.
- **`getCanonicalPath()` collapses `../` traversal** so a malicious `file:///sdcard/../../../data/data/<pkg>/...` cannot escape the check.
- **All three result paths are covered**: single-file (`parseResult`), multi-file (`ClipData`), and the legacy single-URI callback.

`content://` providers streaming the host's private files (the related CVE-2020-15650 / Mozilla bug 1652360 vector) are intentionally out of scope — a legitimate `content://` is the normal selection path, and validating it requires resolving the provider's backing file rather than the URI path.

## Changes

- `flutter_inappwebview_android/.../InAppWebViewChromeClient.java` — new `isPrivateSandboxFileUri()` + `filterSandboxFileUris()` helpers, wired into `onActivityResult` (legacy) and `getSelectedFiles` (single + multi).
- `flutter_inappwebview_android/CHANGELOG.md` — entry under `1.2.0-beta.3`.
