### PR TITLE
fix: backport broken dependency resolution on v6.0.0

### DIFF
--- a/flutter_inappwebview/pubspec.yaml
+++ b/flutter_inappwebview/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_inappwebview
 description: A Flutter plugin that allows you to add an inline webview, to use an headless webview, and to open an in-app browser window.
-version: 6.0.0
+version: 6.0.1
 homepage: https://inappwebview.dev/
 repository: https://github.com/pichillilorenzo/flutter_inappwebview
 issue_tracker: https://github.com/pichillilorenzo/flutter_inappwebview/issues
@@ -20,7 +20,7 @@ dependencies:
     sdk: flutter
   flutter_inappwebview_platform_interface: ^1.0.10
   flutter_inappwebview_android: ^1.0.12
-  flutter_inappwebview_ios: ^1.0.13
+  flutter_inappwebview_ios: '>=1.0.13 <1.1.0'
   flutter_inappwebview_macos: ^1.0.11
   flutter_inappwebview_web: ^1.0.8
 


### PR DESCRIPTION
This commits fixed the broken dependency resolution on ios build as flutter_inappwebview_ios:v1.1.0 requires Xcode 16.

```
[!] CocoaPods could not find compatible versions for pod "OrderedSet":
[!] The abstract target Dummy is not inherited by a concrete target, so the following dependencies won't make it into any targets in your project:
  In snapshot (Podfile.lock):
    - OFTaboolaWrapper (from `OFTaboolaWrapper`)
    OrderedSet (= 5.0.0, ~> 5.0)

  In Podfile:
    flutter_inappwebview_ios (from `../flutter/targets/mobile_entrypoint/.ios/.symlinks/plugins/flutter_inappwebview_ios/ios`) was resolved to 0.0.1, which depends on
      OrderedSet (~> 6.0.3)
```

## Connection with issue(s)

Resolve issue (partially) #2288 

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->

## Testing and Review Notes

<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->


## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable)
