### PR TITLE
Support keyboardDisplayRequiresUserAction to focus automaticlly in iOS

### DIFF
--- a/flutter_inappwebview/lib/src/in_app_webview/in_app_webview_controller.dart
+++ b/flutter_inappwebview/lib/src/in_app_webview/in_app_webview_controller.dart
@@ -290,6 +290,9 @@ class InAppWebViewController {
   Future<InAppWebViewHitTestResult?> getHitTestResult() =>
       platform.getHitTestResult();
 
+  ///{@macro flutter_inappwebview_platform_interface.PlatformInAppWebViewController.requestFocus}
+  Future<void> requestFocus() => platform.requestFocus();
+
   ///{@macro flutter_inappwebview_platform_interface.PlatformInAppWebViewController.clearFocus}
   Future<void> clearFocus() => platform.clearFocus();
 

--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/WebViewChannelDelegate.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/WebViewChannelDelegate.java
@@ -468,6 +468,12 @@ public class WebViewChannelDelegate extends ChannelDelegateImpl {
           result.success(false);
         }
         break;
+      case requestFocus:
+        if (webView != null) {
+          webView.requestFocus();
+        }
+        result.success(true);
+        break;
       case clearFocus:
         if (webView != null) {
           webView.clearFocus();

--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/WebViewChannelDelegateMethods.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/WebViewChannelDelegateMethods.java
@@ -62,6 +62,7 @@ public enum WebViewChannelDelegateMethods {
   saveWebArchive,
   zoomIn,
   zoomOut,
+  requestFocus,
   clearFocus,
   setContextMenu,
   requestFocusNodeHref,

--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/in_app_webview/InputAwareWebView.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/in_app_webview/InputAwareWebView.java
@@ -150,6 +150,11 @@ public class InputAwareWebView extends WebView {
   public void clearFocus() {
     super.clearFocus();
 
+    InputMethodManager inputManager = (InputMethodManager) this.getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+    if (inputManager != null) {
+      inputManager.hideSoftInputFromWindow(this.getWindowToken(), 0);
+    }
+
     if (useHybridComposition) {
       return;
     }

--- a/flutter_inappwebview_android/lib/src/in_app_webview/in_app_webview_controller.dart
+++ b/flutter_inappwebview_android/lib/src/in_app_webview/in_app_webview_controller.dart
@@ -2242,6 +2242,12 @@ class AndroidInAppWebViewController extends PlatformInAppWebViewController
   }
 
   @override
+  Future<void> requestFocus() async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    return await channel?.invokeMethod('requestFocus', args);
+  }
+
+  @override
   Future<void> clearFocus() async {
     Map<String, dynamic> args = <String, dynamic>{};
     return await channel?.invokeMethod('clearFocus', args);

--- a/flutter_inappwebview_ios/ios/Classes/InAppWebView/InAppWebView.swift
+++ b/flutter_inappwebview_ios/ios/Classes/InAppWebView/InAppWebView.swift
@@ -9,6 +9,75 @@ import Flutter
 import Foundation
 import WebKit
 
+// Support `keyboardDisplayRequiresUserAction` to focus automaticlly
+typealias OldClosureType =  @convention(c) (Any, Selector, UnsafeRawPointer, Bool, Bool, Any?) -> Void
+typealias NewClosureType =  @convention(c) (Any, Selector, UnsafeRawPointer, Bool, Bool, Bool, Any?) -> Void
+extension WKWebView{
+    var keyboardDisplayRequiresUserAction: Bool? {
+        get {
+            return self.keyboardDisplayRequiresUserAction
+        }
+        set {
+            self.setKeyboardRequiresUserInteraction(newValue ?? true)
+        }
+    }
+
+    func setKeyboardRequiresUserInteraction( _ value: Bool) {
+        guard let WKContentView: AnyClass = NSClassFromString("WKContentView") else {
+            print("keyboardDisplayRequiresUserAction extension: Cannot find the WKContentView class")
+            return
+        }
+        // For iOS 10, *
+        let sel_10: Selector = sel_getUid("_startAssistingNode:userIsInteracting:blurPreviousNode:userObject:")
+        // For iOS 11.3, *
+        let sel_11_3: Selector = sel_getUid("_startAssistingNode:userIsInteracting:blurPreviousNode:changingActivityState:userObject:")
+        // For iOS 12.2, *
+        let sel_12_2: Selector = sel_getUid("_elementDidFocus:userIsInteracting:blurPreviousNode:changingActivityState:userObject:")
+        // For iOS 13.0, *
+        let sel_13_0: Selector = sel_getUid("_elementDidFocus:userIsInteracting:blurPreviousNode:activityStateChanges:userObject:")
+
+        if let method = class_getInstanceMethod(WKContentView, sel_10) {
+            let originalImp: IMP = method_getImplementation(method)
+            let original: OldClosureType = unsafeBitCast(originalImp, to: OldClosureType.self)
+            let block : @convention(block) (Any, UnsafeRawPointer, Bool, Bool, Any?) -> Void = { (me, arg0, arg1, arg2, arg3) in
+                original(me, sel_10, arg0, !value, arg2, arg3)
+            }
+            let imp: IMP = imp_implementationWithBlock(block)
+            method_setImplementation(method, imp)
+        }
+
+        if let method = class_getInstanceMethod(WKContentView, sel_11_3) {
+            let originalImp: IMP = method_getImplementation(method)
+            let original: NewClosureType = unsafeBitCast(originalImp, to: NewClosureType.self)
+            let block : @convention(block) (Any, UnsafeRawPointer, Bool, Bool, Bool, Any?) -> Void = { (me, arg0, arg1, arg2, arg3, arg4) in
+                original(me, sel_11_3, arg0, !value, arg2, arg3, arg4)
+            }
+            let imp: IMP = imp_implementationWithBlock(block)
+            method_setImplementation(method, imp)
+        }
+
+        if let method = class_getInstanceMethod(WKContentView, sel_12_2) {
+            let originalImp: IMP = method_getImplementation(method)
+            let original: NewClosureType = unsafeBitCast(originalImp, to: NewClosureType.self)
+            let block : @convention(block) (Any, UnsafeRawPointer, Bool, Bool, Bool, Any?) -> Void = { (me, arg0, arg1, arg2, arg3, arg4) in
+                original(me, sel_12_2, arg0, !value, arg2, arg3, arg4)
+            }
+            let imp: IMP = imp_implementationWithBlock(block)
+            method_setImplementation(method, imp)
+        }
+
+        if let method = class_getInstanceMethod(WKContentView, sel_13_0) {
+            let originalImp: IMP = method_getImplementation(method)
+            let original: NewClosureType = unsafeBitCast(originalImp, to: NewClosureType.self)
+            let block : @convention(block) (Any, UnsafeRawPointer, Bool, Bool, Bool, Any?) -> Void = { (me, arg0, arg1, arg2, arg3, arg4) in
+                original(me, sel_13_0, arg0, !value, arg2, arg3, arg4)
+            }
+            let imp: IMP = imp_implementationWithBlock(block)
+            method_setImplementation(method, imp)
+        }
+    }
+}
+
 public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                             WKNavigationDelegate, WKScriptMessageHandler, UIGestureRecognizerDelegate,
                             WKDownloadDelegate,
@@ -81,6 +150,7 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         }
         self.contextMenu = contextMenu
         self.initialUserScripts = userScripts
+        self.keyboardDisplayRequiresUserAction = false
         uiDelegate = self
         navigationDelegate = self
         scrollView.delegate = self

--- a/flutter_inappwebview_ios/ios/Classes/InAppWebView/InAppWebView.swift
+++ b/flutter_inappwebview_ios/ios/Classes/InAppWebView/InAppWebView.swift
@@ -3208,6 +3208,10 @@ if(window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)] != null) {
         }
     }
     
+    public func requestFocus() {
+        self.scrollView.subviews.first?.becomeFirstResponder()
+    }
+    
     public func clearFocus() {
         self.scrollView.subviews.first?.resignFirstResponder()
     }

--- a/flutter_inappwebview_ios/ios/Classes/InAppWebView/WebViewChannelDelegate.swift
+++ b/flutter_inappwebview_ios/ios/Classes/InAppWebView/WebViewChannelDelegate.swift
@@ -344,6 +344,10 @@ public class WebViewChannelDelegate: ChannelDelegate {
                 result(nil)
             }
             break
+        case .requestFocus:
+            webView?.requestFocus()
+            result(true)
+            break
         case .clearFocus:
             webView?.clearFocus()
             result(true)

--- a/flutter_inappwebview_ios/ios/Classes/InAppWebView/WebViewChannelDelegateMethods.swift
+++ b/flutter_inappwebview_ios/ios/Classes/InAppWebView/WebViewChannelDelegateMethods.swift
@@ -58,6 +58,7 @@ public enum WebViewChannelDelegateMethods: String {
     case hasOnlySecureContent = "hasOnlySecureContent"
     case getSelectedText = "getSelectedText"
     case getHitTestResult = "getHitTestResult"
+    case requestFocus = "requestFocus"
     case clearFocus = "clearFocus"
     case setContextMenu = "setContextMenu"
     case requestFocusNodeHref = "requestFocusNodeHref"

--- a/flutter_inappwebview_ios/lib/src/in_app_webview/in_app_webview_controller.dart
+++ b/flutter_inappwebview_ios/lib/src/in_app_webview/in_app_webview_controller.dart
@@ -2229,6 +2229,12 @@ class IOSInAppWebViewController extends PlatformInAppWebViewController
   }
 
   @override
+  Future<void> requestFocus() async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    return await channel?.invokeMethod('requestFocus', args);
+  }
+
+  @override
   Future<void> clearFocus() async {
     Map<String, dynamic> args = <String, dynamic>{};
     return await channel?.invokeMethod('clearFocus', args);

--- a/flutter_inappwebview_platform_interface/lib/src/in_app_webview/platform_inappwebview_controller.dart
+++ b/flutter_inappwebview_platform_interface/lib/src/in_app_webview/platform_inappwebview_controller.dart
@@ -1048,6 +1048,13 @@ abstract class PlatformInAppWebViewController extends PlatformInterface
         'getHitTestResult is not implemented on the current platform');
   }
 
+  ///{@template flutter_inappwebview_platform_interface.PlatformInAppWebViewController.requestFocus}
+  ///{@endtemplate}
+  Future<void> requestFocus() {
+    throw UnimplementedError(
+        'requestFocus is not implemented on the current platform');
+  }
+
   ///{@template flutter_inappwebview_platform_interface.PlatformInAppWebViewController.clearFocus}
   ///Clears the current focus. On iOS and Android native WebView, it will clear also, for example, the current text selection.
   ///


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue: [1974](https://github.com/pichillilorenzo/flutter_inappwebview/issues/1974),  [1425](https://github.com/pichillilorenzo/flutter_inappwebview/issues/1425)

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->

Connected to #???

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->

## Testing and Review Notes

<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->


## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [ ] Add keyboardDisplayRequiresUserAction to focus automaticlly in iOS
- [ ] Close keyboard when call `clearFocus` in Android
- [ ] Support `requestFocus` method on WebView
