### PR TITLE
fix: Fix JavaScript handlers in InAppBrowser for Android

### DIFF
--- a/flutter_inappwebview/example/integration_test/in_app_browser/javascript_handler.dart
+++ b/flutter_inappwebview/example/integration_test/in_app_browser/javascript_handler.dart
@@ -1,0 +1,54 @@
+part of 'main.dart';
+
+void javascriptHandler() {
+  final shouldSkip = kIsWeb
+      ? true
+      : ![
+          TargetPlatform.android,
+          TargetPlatform.iOS,
+          TargetPlatform.macOS,
+        ].contains(defaultTargetPlatform);
+
+  skippableTest('JavaScript Handler', () async {
+    final Completer<void> handlerFoo = Completer<void>();
+    final Completer<void> handlerFooWithArgs = Completer<void>();
+    final List<dynamic> messagesReceived = <dynamic>[];
+
+    MyInAppBrowser inAppBrowser = MyInAppBrowser();
+    inAppBrowser.browserCreated.future.then((_) {
+      inAppBrowser.webViewController!.addJavaScriptHandler(
+          handlerName: 'handlerFoo',
+          callback: (args) {
+            handlerFoo.complete();
+            return Foo(bar: 'bar_value', baz: 'baz_value');
+          });
+      inAppBrowser.webViewController!.addJavaScriptHandler(
+          handlerName: 'handlerFooWithArgs',
+          callback: (args) {
+            messagesReceived.add(args[0] as int);
+            messagesReceived.add(args[1] as bool);
+            messagesReceived.add(args[2] as List<dynamic>?);
+            messagesReceived
+                .add(args[3]?.cast<String, String>() as Map<String, String>?);
+            messagesReceived
+                .add(args[4]?.cast<String, String>() as Map<String, String>?);
+            handlerFooWithArgs.complete();
+          });
+    });
+    await inAppBrowser.openFile(
+        assetFilePath:
+            'test_assets/in_app_webview_javascript_handler_test.html');
+
+    await handlerFoo.future;
+    await handlerFooWithArgs.future;
+
+    expect(messagesReceived[0], 1);
+    expect(messagesReceived[1], true);
+    expect(listEquals(messagesReceived[2] as List<dynamic>?, ["bar", 5]), true);
+    expect(mapEquals(messagesReceived[3], {"foo": "baz"}), true);
+    expect(
+        mapEquals(
+            messagesReceived[4], {"bar": "bar_value", "baz": "baz_value"}),
+        true);
+  }, skip: shouldSkip);
+}

--- a/flutter_inappwebview/example/integration_test/in_app_browser/main.dart
+++ b/flutter_inappwebview/example/integration_test/in_app_browser/main.dart
@@ -1,17 +1,21 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:flutter_test/flutter_test.dart';
+
 import '../constants.dart';
 import '../util.dart';
 
+part 'custom_menu_items.dart';
+part 'hide_and_show.dart';
+part 'javascript_handler.dart';
 part 'open_data_and_close.dart';
 part 'open_file_and_close.dart';
 part 'open_url_and_close.dart';
 part 'set_get_settings.dart';
-part 'hide_and_show.dart';
-part 'custom_menu_items.dart';
 
 void main() {
   final shouldSkip = kIsWeb;
@@ -23,5 +27,6 @@ void main() {
     setGetSettings();
     hideAndShow();
     customMenuItems();
+    javascriptHandler();
   }, skip: shouldSkip);
 }

--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/in_app_browser/InAppBrowserActivity.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/in_app_browser/InAppBrowserActivity.java
@@ -145,6 +145,7 @@ public class InAppBrowserActivity extends AppCompatActivity implements InAppBrow
     webView.customSettings = webViewSettings;
     webView.contextMenu = contextMenu;
 
+    webView.prepareAndAddUserScripts();
     List<UserScript> userScripts = new ArrayList<>();
     if (initialUserScripts != null) {
       for (Map<String, Object> initialUserScript : initialUserScripts) {


### PR DESCRIPTION
Android InAppBrowserActivity would not call `prepareAndAddUserScripts` when `WebViewFeature.DOCUMENT_START_SCRIPT`, which would prevent shims like `callHandler` from being injected. 

Fix this by calling `prepareAndAddUserScripts` during OnCreate.

Other injections were likely also broken but this is the one I needed.

I also added  an integration test for JavaScript handlers in in_app_browser.  This test fails without this change on Android emulators 33+.

## Connection with issue(s)

Resolve issue #1973 

## Testing and Review Notes

So far as I can tell, we do not need to wrap `prepareAndAddUserScripts` to check if `WebViewFeature.DOCUMENT_START_SCRIPT` is supported to prevent a double call, as `addPluginScript` does this already. 
