### PR TITLE
windows: fix WebViewEnvironment dispose crash

### DIFF
--- a/flutter_inappwebview_windows/windows/webview_environment/webview_environment.cpp
+++ b/flutter_inappwebview_windows/windows/webview_environment/webview_environment.cpp
@@ -103,7 +103,7 @@ namespace flutter_inappwebview_plugin
                 }
                 return S_OK;
               }
-            ).Get(), nullptr);
+            ).Get(), &newBrowserVersionAvailableToken_);
             failedLog(add_NewBrowserVersionAvailable_HResult);
 
             if (auto environment5 = environment_.try_query<ICoreWebView2Environment5>()) {
@@ -122,7 +122,7 @@ namespace flutter_inappwebview_plugin
                   }
                   return S_OK;
                 }
-              ).Get(), nullptr);
+              ).Get(), &browserProcessExitedToken_);
               failedLog(add_BrowserProcessExited_HResult);
             }
 
@@ -152,7 +152,7 @@ namespace flutter_inappwebview_plugin
                   }
                   return S_OK;
                 }
-              ).Get(), nullptr);
+              ).Get(), &processInfosChangedToken_);
               failedLog(add_ProcessInfosChanged_HResult);
             }
 
@@ -307,6 +307,15 @@ namespace flutter_inappwebview_plugin
 
   WebViewEnvironment::~WebViewEnvironment()
   {
+    if (environment_ != nullptr) {
+       if (auto environment8 = environment_.try_query<ICoreWebView2Environment8>()) {
+          auto add_ProcessInfosChanged_HResult = environment8->remove_ProcessInfosChanged(processInfosChangedToken_);
+       }
+       if (auto environment5 = environment_.try_query<ICoreWebView2Environment5>()) {
+          auto add_BrowserProcessExited_HResult = environment5->remove_BrowserProcessExited(browserProcessExitedToken_);
+       }
+       environment_->remove_NewBrowserVersionAvailable(newBrowserVersionAvailableToken_);
+    }
     debugLog("dealloc WebViewEnvironment");
     environment_ = nullptr;
   }

--- a/flutter_inappwebview_windows/windows/webview_environment/webview_environment.cpp
+++ b/flutter_inappwebview_windows/windows/webview_environment/webview_environment.cpp
@@ -307,12 +307,12 @@ namespace flutter_inappwebview_plugin
 
   WebViewEnvironment::~WebViewEnvironment()
   {
-    if (environment_ != nullptr) {
+    if (environment_) {
        if (auto environment8 = environment_.try_query<ICoreWebView2Environment8>()) {
-          auto add_ProcessInfosChanged_HResult = environment8->remove_ProcessInfosChanged(processInfosChangedToken_);
+          environment8->remove_ProcessInfosChanged(processInfosChangedToken_);
        }
        if (auto environment5 = environment_.try_query<ICoreWebView2Environment5>()) {
-          auto add_BrowserProcessExited_HResult = environment5->remove_BrowserProcessExited(browserProcessExitedToken_);
+          environment5->remove_BrowserProcessExited(browserProcessExitedToken_);
        }
        environment_->remove_NewBrowserVersionAvailable(newBrowserVersionAvailableToken_);
     }

--- a/flutter_inappwebview_windows/windows/webview_environment/webview_environment.h
+++ b/flutter_inappwebview_windows/windows/webview_environment/webview_environment.h
@@ -40,6 +40,9 @@ namespace flutter_inappwebview_plugin
 
   private:
     wil::com_ptr<ICoreWebView2Environment> environment_;
+    EventRegistrationToken processInfosChangedToken_ = { 0 };
+    EventRegistrationToken browserProcessExitedToken_ = { 0 };
+    EventRegistrationToken newBrowserVersionAvailableToken_ = { 0 };
     WNDCLASS windowClass_ = {};
   };
 }


### PR DESCRIPTION
webViewEnvironment.dispose() will cause a wild pointer crash. The reason is that after WebViewEnvironment is destroyed, the event callbacks such as add_ProcessInfosChanged access the WebViewEnvironment this pointer, causing a wild pointer crash. Fix: Cancel the callback registration of related events during destruction