### PR TITLE
Fixed recursive calling toMap in AndroidInternalStoragePathHandler

### DIFF
--- a/flutter_inappwebview_android/lib/src/webview_asset_loader.dart
+++ b/flutter_inappwebview_android/lib/src/webview_asset_loader.dart
@@ -195,7 +195,7 @@ class AndroidInternalStoragePathHandler
 
   @override
   Map<String, dynamic> toMap({EnumMethod? enumMethod}) {
-    return {...toMap(), 'directory': directory};
+    return {...super.toMap(), 'directory': directory};
   }
 }
 


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #2451

## Testing and Review Notes

Try to load an asset from filesystem directory.

