### PR TITLE
Goo ring x fix windows call handler crash

### DIFF
--- a/flutter_inappwebview_windows/lib/src/in_app_webview/custom_platform_view.dart
+++ b/flutter_inappwebview_windows/lib/src/in_app_webview/custom_platform_view.dart
@@ -295,12 +295,18 @@ class _CustomPlatformViewState extends State<CustomPlatformView>
 
     _controller.initialize(
         onPlatformViewCreated: (id) {
+          if (!mounted) {
+            return;
+          }
           widget.onPlatformViewCreated?.call(id);
           setState(() {});
         },
         arguments: widget.creationParams);
 
     _listener = AppLifecycleListener(onStateChange: (state) {
+      if (!mounted) {
+        return;
+      }
       if ([AppLifecycleState.resumed, AppLifecycleState.hidden]
           .contains(state)) {
         _reportSurfaceSize();

--- a/flutter_inappwebview_windows/lib/src/in_app_webview/custom_platform_view.dart
+++ b/flutter_inappwebview_windows/lib/src/in_app_webview/custom_platform_view.dart
@@ -473,6 +473,9 @@ class _CustomPlatformViewState extends State<CustomPlatformView>
     final box = _key.currentContext?.findRenderObject() as RenderBox?;
     if (box != null) {
       await _controller.ready;
+      if (!mounted) {
+        return;
+      }
       final position = box.localToGlobal(Offset.zero);
       unawaited(_controller._setPosition(
           position, widget.scaleFactor ?? window.devicePixelRatio));

--- a/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview.cpp
+++ b/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview.cpp
@@ -2704,7 +2704,7 @@ namespace flutter_inappwebview_plugin
           callback->defaultBehaviour = [this, callHandlerID](const std::optional<const flutter::EncodableValue*> response)
             {
               std::string json = "null";
-              if (response.has_value() && !response.value()->IsNull()) {
+              if (response.has_value() && response.value() && !response.value()->IsNull()) {
                 json = std::get<std::string>(*(response.value()));
               }
 


### PR DESCRIPTION
Fixed the crash caused by calling a non-existent handler in js under Windows.
js code for test:
window.flutter_inappwebview.callHandler('testCrash').then(function(result) {
   return result;
}).catch(function() {
});
