### PR TITLE
Fix gesture recognition delay prevention for latest Flutter versions

### DIFF
--- a/flutter_inappwebview_ios/ios/Classes/InAppWebView/InAppWebView.swift
+++ b/flutter_inappwebview_ios/ios/Classes/InAppWebView/InAppWebView.swift
@@ -247,7 +247,8 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         // https://github.com/pichillilorenzo/flutter_inappwebview/pull/1665
         if preventGestureDelay, let gestures = superview?.superview?.gestureRecognizers {
             for gesture in gestures {
-                if NSStringFromClass(type(of: gesture)) == "DelayingGestureRecognizer" {
+                let gestureType = NSStringFromClass(type(of: gesture))
+                if gestureType == "DelayingGestureRecognizer" || gestureType == "FlutterDelayingGestureRecognizer" {
                     gesture.isEnabled = false
                 }
             }


### PR DESCRIPTION
…ions

## Connection with issue(s)

Resolve issue #???

There is no opened issue. I created the PR directly

Connected to PR #1665

The PR #1665 introduced `preventGestureDelay` on iOS. On recent Flutter version this workaround is broken due to naming issues

## Testing and Review Notes

I only extended the class name check to embrace also new naming
