### PR TITLE
bug-fix: update evaluateJavaScript method signature to use @MainActor…

### DIFF
--- a/flutter_inappwebview_ios/ios/Classes/InAppWebView/InAppWebView.swift
+++ b/flutter_inappwebview_ios/ios/Classes/InAppWebView/InAppWebView.swift
@@ -1541,7 +1541,7 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         super.evaluateJavaScript(javaScriptString, completionHandler: completionHandler)
     }
 #else
-    public override func evaluateJavaScript(_ javaScriptString: String, completionHandler: ((Any?, Error?) -> Void)? = nil) {
+    open override func evaluateJavaScript(_ javaScriptString: String, completionHandler: (@MainActor (Any?, (any Error)?) -> Void)? = nil) {
         if let applePayAPIEnabled = settings?.applePayAPIEnabled, applePayAPIEnabled {
             if let completionHandler = completionHandler {
                 completionHandler(nil, nil)

--- a/flutter_inappwebview_macos/macos/Classes/InAppWebView/InAppWebView.swift
+++ b/flutter_inappwebview_macos/macos/Classes/InAppWebView/InAppWebView.swift
@@ -939,7 +939,7 @@ public class InAppWebView: WKWebView, WKUIDelegate,
         super.evaluateJavaScript(javaScriptString, completionHandler: completionHandler)
     }
 #else
-    public override func evaluateJavaScript(_ javaScriptString: String, completionHandler: ((Any?, Error?) -> Void)? = nil) {
+    open override func evaluateJavaScript(_ javaScriptString: String, completionHandler: (@MainActor (Any?, (any Error)?) -> Void)? = nil) {
         if let applePayAPIEnabled = settings?.applePayAPIEnabled, applePayAPIEnabled {
             if let completionHandler = completionHandler {
                 completionHandler(nil, nil)


### PR DESCRIPTION
Title
Fix evaluateJavaScript override error for Xcode 16

Description
This PR fixes the override issue for evaluateJavaScript in iOS and macOS InAppWebView classes when building with Xcode 16. The change updates the function signature to align with the latest Swift updates.
Testing and Review Notes
To test this fix:

Build a Flutter project using flutter_inappwebview with Xcode 16.

Ensure that no override error appears for evaluateJavaScript.

Verify that JavaScript execution still functions correctly in InAppWebView.

To Do

- [x] Verify that the issue is resolved with this change

- [x]  Ensure compatibility with previous Xcode versions

- [x] Add testing notes in PR description

- [ ] Request review from maintainers