### PR TITLE
Fix: keepAlive not working when URL changed

### DIFF
--- a/flutter_inappwebview_android/lib/src/in_app_webview/in_app_webview_controller.dart
+++ b/flutter_inappwebview_android/lib/src/in_app_webview/in_app_webview_controller.dart
@@ -172,6 +172,10 @@ class AndroidInAppWebViewController extends PlatformInAppWebViewController
               props.webMessageChannels as Set<AndroidWebMessageChannel>;
           _webMessageListeners =
               props.webMessageListeners as Set<AndroidWebMessageListener>;
+          // restore the last URL if available
+          if (props.currentUrl != null) {
+            loadUrl(urlRequest: URLRequest(url: props.currentUrl));
+          }
         }
       }
     }
@@ -214,6 +218,18 @@ class AndroidInAppWebViewController extends PlatformInAppWebViewController
             _inAppBrowserEventHandler != null) {
           String? url = call.arguments["url"];
           WebUri? uri = url != null ? WebUri(url) : null;
+          
+          // Update the current URL in the keepAlive properties
+          final keepAlive = webviewParams is PlatformInAppWebViewWidgetCreationParams ?
+              (webviewParams as PlatformInAppWebViewWidgetCreationParams).keepAlive : null;
+          if (keepAlive != null && uri != null) {
+            InAppWebViewControllerKeepAliveProps? props = _keepAliveMap[keepAlive];
+            if (props != null) {
+              props.currentUrl = uri;
+              _keepAliveMap[keepAlive] = props;
+            }
+          }
+          
           if (webviewParams != null && webviewParams!.onLoadStop != null)
             webviewParams!.onLoadStop!(_controllerFromPlatform, uri);
           else

--- a/flutter_inappwebview_ios/lib/src/in_app_webview/in_app_webview_controller.dart
+++ b/flutter_inappwebview_ios/lib/src/in_app_webview/in_app_webview_controller.dart
@@ -170,6 +170,10 @@ class IOSInAppWebViewController extends PlatformInAppWebViewController
               props.webMessageChannels as Set<IOSWebMessageChannel>;
           _webMessageListeners =
               props.webMessageListeners as Set<IOSWebMessageListener>;
+          // restore the last URL if available
+          if (props.currentUrl != null) {
+            loadUrl(urlRequest: URLRequest(url: props.currentUrl));
+          }
         }
       }
     }
@@ -212,6 +216,18 @@ class IOSInAppWebViewController extends PlatformInAppWebViewController
             _inAppBrowserEventHandler != null) {
           String? url = call.arguments["url"];
           WebUri? uri = url != null ? WebUri(url) : null;
+          
+          // Update the current URL in the keepAlive properties
+          final keepAlive = webviewParams is PlatformInAppWebViewWidgetCreationParams ?
+              (webviewParams as PlatformInAppWebViewWidgetCreationParams).keepAlive : null;
+          if (keepAlive != null && uri != null) {
+            InAppWebViewControllerKeepAliveProps? props = _keepAliveMap[keepAlive];
+            if (props != null) {
+              props.currentUrl = uri;
+              _keepAliveMap[keepAlive] = props;
+            }
+          }
+          
           if (webviewParams != null && webviewParams!.onLoadStop != null)
             webviewParams!.onLoadStop!(_controllerFromPlatform, uri);
           else
@@ -1605,7 +1621,7 @@ class IOSInAppWebViewController extends PlatformInAppWebViewController
         html =
             await (await htmlRequest.close()).transform(Utf8Decoder()).join();
       } catch (e) {
-        developer.log(e.toString(), name: this.runtimeType.toString());
+        developer.log(e.toString(), name: runtimeType.toString());
       }
     }
 

--- a/flutter_inappwebview_platform_interface/lib/src/in_app_webview/in_app_webview_keep_alive.dart
+++ b/flutter_inappwebview_platform_interface/lib/src/in_app_webview/in_app_webview_keep_alive.dart
@@ -29,6 +29,7 @@ class InAppWebViewControllerKeepAliveProps {
   Set<PlatformWebMessageChannel> webMessageChannels = Set();
   Set<PlatformWebMessageListener> webMessageListeners = Set();
   Map<String, Function(dynamic data)> devToolsProtocolEventListenerMap;
+  WebUri? currentUrl;
 
   InAppWebViewControllerKeepAliveProps(
       {this.javaScriptHandlersMap = const {},
@@ -37,5 +38,6 @@ class InAppWebViewControllerKeepAliveProps {
       this.injectedScriptsFromURL = const {},
       this.webMessageChannels = const {},
       this.webMessageListeners = const {},
-      this.devToolsProtocolEventListenerMap = const {}});
+      this.devToolsProtocolEventListenerMap = const {},
+      this.currentUrl});
 }


### PR DESCRIPTION
## Issue
When using `InAppWebViewKeepAlive`, if the URL is changed from the initial URL and the WebView is removed and re-added to the widget tree, it loads the initial URL instead of the last URL that was navigated to.

Steps to reproduce:
1. Load `https://jumble.social/` and set `keepAlive = InAppWebViewKeepAlive()`
2. Navigate to a different URL, like `https://jumble.social/notes/bbb`
3. Close the WebView
4. Reopen the WebView with the same `InAppWebViewKeepAlive` object
5. The WebView loads `https://jumble.social/` instead of `https://jumble.social/notes/bbb`

## Fix
This PR adds URL tracking to the keepAlive functionality:

1. Added a `currentUrl` property to the `InAppWebViewControllerKeepAliveProps` class
2. Updated the `onLoadStop` event handlers in Android and iOS implementations to save the current URL to the keepAlive properties
3. Modified the controller initialization code to restore the last URL when reusing a keepAlive object

Fixes #2613
