### PR TITLE
fix: remove printing headers inside server listen

### DIFF
--- a/flutter_inappwebview_platform_interface/lib/src/in_app_localhost_server.dart
+++ b/flutter_inappwebview_platform_interface/lib/src/in_app_localhost_server.dart
@@ -130,7 +130,6 @@ class DefaultInAppLocalhostServer extends PlatformInAppLocalhostServer {
           }
 
           request.response.headers.contentType = contentType;
-          print(request.response.headers);
           request.response.add(body);
           request.response.close();
         });


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #2630

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->

## Testing and Review Notes
Running a local host server should no longer print headers on every request
<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->


## Screenshots or Videos
![image](https://github.com/user-attachments/assets/359b14a4-f23e-494c-afb5-77ff93573022)


<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable)
