### PR TITLE
Add WKWebView proxy support for iOS 17+

### DIFF
--- a/flutter_inappwebview_ios/ios/Classes/InAppWebView/InAppWebView.swift
+++ b/flutter_inappwebview_ios/ios/Classes/InAppWebView/InAppWebView.swift
@@ -722,6 +722,15 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
             if #available(iOS 15.0, *) {
                 configuration.upgradeKnownHostsToHTTPS = settings.upgradeKnownHostsToHTTPS
             }
+            
+            if #available(iOS 17.0, *) {
+                let dataStore = WKWebsiteDataStore.default()
+                let newDataStore = WKWebsiteDataStore.nonPersistent()
+                newDataStore.proxyConfigurations = dataStore.proxyConfigurations
+                
+                // Set new websiteDataStore
+                configuration.websiteDataStore = newDataStore
+            }
         }
         
         return configuration

--- a/flutter_inappwebview_ios/ios/Classes/ProxyManager.swift
+++ b/flutter_inappwebview_ios/ios/Classes/ProxyManager.swift
@@ -9,7 +9,7 @@ import WebKit
 @available(iOS 17.0, *)
 public class ProxyManager: ChannelDelegate {
     static let METHOD_CHANNEL_NAME = "com.pichillilorenzo/flutter_inappwebview_proxycontroller"
-
+    
     private var plugin: SwiftFlutterPlugin?
 
     init(plugin: SwiftFlutterPlugin) {
@@ -42,12 +42,10 @@ public class ProxyManager: ChannelDelegate {
     public func setProxyOverride(_ settings: ProxySettings) {
         let proxyConfigurations = settings.toProxyConfigurations()
         WKWebsiteDataStore.default().proxyConfigurations = proxyConfigurations
-        WKWebsiteDataStore.nonPersistent().proxyConfigurations = proxyConfigurations
     }
     
     public func clearProxyOverride() {
         WKWebsiteDataStore.default().proxyConfigurations = []
-        WKWebsiteDataStore.nonPersistent().proxyConfigurations = []
     }
 
     public override func dispose() {


### PR DESCRIPTION
### Why

WKWebView has limited support for proxy settings. Starting from iOS 17, Apple allows setting `proxyConfigurations` on a `WKWebsiteDataStore`. However, this only works with non-persistent stores. This update enables that support in the context of `InAppWebView`.

## Connection with issue(s)

Resolve issue #???

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->

Connected to #???

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->

## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable)
