### PR TITLE
fix: add window context handling for AJAX interception in iframe 

### DIFF
--- a/flutter_inappwebview_ios/ios/Classes/PluginScriptsJS/InterceptAjaxRequestJS.swift
+++ b/flutter_inappwebview_ios/ios/Classes/PluginScriptsJS/InterceptAjaxRequestJS.swift
@@ -31,7 +31,8 @@ func createInterceptOnlyAsyncAjaxRequestsPluginScript(onlyAsync: Bool) -> Plugin
 }
 
 let INTERCEPT_AJAX_REQUEST_JS_SOURCE = """
-\(FLAG_VARIABLE_FOR_SHOULD_INTERCEPT_AJAX_REQUEST_JS_SOURCE) = true;
+var w = (window.top == null || window.top === window) ? window : window.top;
+w.\(FLAG_VARIABLE_FOR_SHOULD_INTERCEPT_AJAX_REQUEST_JS_SOURCE) = true;
 (function(ajax) {
   var send = ajax.prototype.send;
   var open = ajax.prototype.open;


### PR DESCRIPTION
## Problem
The AJAX interception functionality fails when the web content is loaded in an iframe context, causing captcha and other AJAX-dependent features to break. This occurs because the FLAG_VARIABLE is not properly referenced to the top window context.

## Solution
- Added window reference pattern: `var w = (window.top == null || window.top === window) ? window : window.top;`
- Updated FLAG_VARIABLE assignment to use top window context: `w.FLAG_VARIABLE = true;`
- Ensures AJAX interception works consistently in both main window and iframe contexts

## Impact
- Fixes captcha functionality in iframe scenarios
- Maintains backward compatibility with existing implementations
- Follows security best practices for iframe context handling
- No breaking changes to the public API

## Connection with issue(s)

Resolve issue #2227

## Testing and Review Notes

## Testing
- Verified captcha works in iframe contexts
- Confirmed no regression in main window scenarios
- Tested with various web content types
