### PR TITLE
fix: add window context handling for AJAX interception in iframe scen…

### DIFF
--- a/flutter_inappwebview_ios/ios/Classes/PluginScriptsJS/InterceptAjaxRequestJS.swift
+++ b/flutter_inappwebview_ios/ios/Classes/PluginScriptsJS/InterceptAjaxRequestJS.swift
@@ -31,7 +31,8 @@ func createInterceptOnlyAsyncAjaxRequestsPluginScript(onlyAsync: Bool) -> Plugin
 }
 
 let INTERCEPT_AJAX_REQUEST_JS_SOURCE = """
-\(FLAG_VARIABLE_FOR_SHOULD_INTERCEPT_AJAX_REQUEST_JS_SOURCE) = true;
+var w = (window.top == null || window.top === window) ? window : window.top;
+w.\(FLAG_VARIABLE_FOR_SHOULD_INTERCEPT_AJAX_REQUEST_JS_SOURCE) = true;
 (function(ajax) {
   var send = ajax.prototype.send;
   var open = ajax.prototype.open;


### PR DESCRIPTION
## Problem
The AJAX interception functionality fails when the web content is loaded in an iframe context, causing captcha and other AJAX-dependent features to break. This occurs because the FLAG_VARIABLE is not properly referenced to the top window context.

## Solution
- Added window reference pattern: `var w = (window.top == null || window.top === window) ? window : window.top;`
- Updated FLAG_VARIABLE assignment to use top window context: `w.FLAG_VARIABLE = true;`
- Ensures AJAX interception works consistently in both main window and iframe contexts

## Impact
- Fixes captcha functionality in iframe scenarios
- Maintains backward compatibility with existing implementations
- Follows security best practices for iframe context handling
- No breaking changes to the public API

## Connection with issue(s)

Resolve issue #???

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->

Connected to #???

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->

## Testing and Review Notes

<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->


## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable)
