### PR TITLE
fix analysis failed on pub.dev (fix analysis_options.yaml)

### DIFF
--- a/flutter_inappwebview/analysis_options.yaml
+++ b/flutter_inappwebview/analysis_options.yaml
@@ -2,8 +2,8 @@ include: package:flutter_lints/flutter.yaml
 
 linter:
   rules:
-    constant_identifier_names: ignore
-    deprecated_member_use_from_same_package: ignore
+    constant_identifier_names: false
+    deprecated_member_use_from_same_package: false
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/flutter_inappwebview/example/analysis_options.yaml
+++ b/flutter_inappwebview/example/analysis_options.yaml
@@ -11,8 +11,8 @@ include: package:flutter_lints/flutter.yaml
 
 linter:
   rules:
-    constant_identifier_names: ignore
-    deprecated_member_use_from_same_package: ignore
+    constant_identifier_names: false
+    deprecated_member_use_from_same_package: false
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/flutter_inappwebview_android/analysis_options.yaml
+++ b/flutter_inappwebview_android/analysis_options.yaml
@@ -2,8 +2,8 @@ include: package:flutter_lints/flutter.yaml
 
 linter:
   rules:
-    constant_identifier_names: ignore
-    deprecated_member_use_from_same_package: ignore
+    constant_identifier_names: false
+    deprecated_member_use_from_same_package: false
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/flutter_inappwebview_ios/analysis_options.yaml
+++ b/flutter_inappwebview_ios/analysis_options.yaml
@@ -2,8 +2,8 @@ include: package:flutter_lints/flutter.yaml
 
 linter:
   rules:
-    constant_identifier_names: ignore
-    deprecated_member_use_from_same_package: ignore
+    constant_identifier_names: false
+    deprecated_member_use_from_same_package: false
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/flutter_inappwebview_macos/analysis_options.yaml
+++ b/flutter_inappwebview_macos/analysis_options.yaml
@@ -2,8 +2,8 @@ include: package:flutter_lints/flutter.yaml
 
 linter:
   rules:
-    constant_identifier_names: ignore
-    deprecated_member_use_from_same_package: ignore
+    constant_identifier_names: false
+    deprecated_member_use_from_same_package: false
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/flutter_inappwebview_platform_interface/analysis_options.yaml
+++ b/flutter_inappwebview_platform_interface/analysis_options.yaml
@@ -2,8 +2,8 @@ include: package:flutter_lints/flutter.yaml
 
 linter:
   rules:
-    constant_identifier_names: ignore
-    deprecated_member_use_from_same_package: ignore
+    constant_identifier_names: false
+    deprecated_member_use_from_same_package: false
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/flutter_inappwebview_web/analysis_options.yaml
+++ b/flutter_inappwebview_web/analysis_options.yaml
@@ -2,8 +2,8 @@ include: package:flutter_lints/flutter.yaml
 
 linter:
   rules:
-    constant_identifier_names: ignore
-    deprecated_member_use_from_same_package: ignore
+    constant_identifier_names: false
+    deprecated_member_use_from_same_package: false
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/flutter_inappwebview_windows/analysis_options.yaml
+++ b/flutter_inappwebview_windows/analysis_options.yaml
@@ -2,8 +2,8 @@ include: package:flutter_lints/flutter.yaml
 
 linter:
   rules:
-    constant_identifier_names: ignore
-    deprecated_member_use_from_same_package: ignore
+    constant_identifier_names: false
+    deprecated_member_use_from_same_package: false
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #2757

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->

## Testing and Review Notes

<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->

test command (on repository)
```bash
# if not installed, run `dart pub global activate pana`
pana --no-dartdoc flutter_inappwebview && \
pana --no-dartdoc flutter_inappwebview_macos && \
pana --no-dartdoc flutter_inappwebview_windows && \
pana --no-dartdoc flutter_inappwebview_android && \
pana --no-dartdoc flutter_inappwebview_platform_interface && \
pana --no-dartdoc flutter_inappwebview_ios && \
pana --no-dartdoc flutter_inappwebview_web
```
*`--no-dartdoc` is used to reduce analysis time.

## Screenshots or Videos

test command result (logs)
<details>
<summary>
see logs
</summary>

```bash
**pana --no-dartdoc flutter_inappwebview && \
pana --no-dartdoc flutter_inappwebview_macos && \
pana --no-dartdoc flutter_inappwebview_windows && \
pana --no-dartdoc flutter_inappwebview_android && \
pana --no-dartdoc flutter_inappwebview_platform_interface && \
pana --no-dartdoc flutter_inappwebview_ios && \
pana --no-dartdoc flutter_inappwebview_web
2025-12-30 16:15:33.742281 WARNING: Flutter SDK path was not specified, pana will use the default Dart SDK to run `dart analyze` on Flutter packages.
2025-12-30 16:15:33.747941 INFO: Running `dart --version`...
2025-12-30 16:15:33.793141 INFO: Running `flutter --no-version-check --version --machine`...
2025-12-30 16:15:34.072684 INFO: Running `git rev-parse --show-toplevel`...
2025-12-30 16:15:34.700963 INFO: Running `flutter --no-version-check pub pub get --no-example`...
2025-12-30 16:15:35.545750 INFO: Running `flutter --no-version-check pub pub get --no-example`...
2025-12-30 16:15:35.926771 INFO: Running `flutter --no-version-check pub pub outdated --json --up-to-date --no-dev-dependencies --no-dependency-overrides`...
2025-12-30 16:15:36.514811 INFO: Analyzing package...
2025-12-30 16:15:36.523403 INFO: Running `dart analyze --format machine lib`...
2025-12-30 16:15:39.060650 INFO: Running `git init`...
2025-12-30 16:15:39.071120 INFO: Running `git remote add origin https://github.com/pichillilorenzo/flutter_inappwebview`...
2025-12-30 16:15:39.078835 INFO: Running `git remote show origin`...
2025-12-30 16:15:39.560836 INFO: Running `git fetch --depth 1 --no-recurse-submodules origin master`...
2025-12-30 16:15:41.043280 INFO: Running `git ls-tree -r --name-only --full-tree origin/master`...
2025-12-30 16:15:41.053954 INFO: Running `git show origin/master:dev_packages/flutter_inappwebview_internal_annotations/pubspec.yaml`...
2025-12-30 16:15:41.061684 INFO: Running `git show origin/master:dev_packages/generators/pubspec.yaml`...
2025-12-30 16:15:41.068542 INFO: Running `git show origin/master:flutter_inappwebview/example/pubspec.yaml`...
2025-12-30 16:15:41.076613 INFO: Running `git show origin/master:flutter_inappwebview/pubspec.yaml`...
2025-12-30 16:15:41.085602 INFO: Running `git show origin/master:flutter_inappwebview_android/example/pubspec.yaml`...
2025-12-30 16:15:41.093223 INFO: Running `git show origin/master:flutter_inappwebview_android/pubspec.yaml`...
2025-12-30 16:15:41.100622 INFO: Running `git show origin/master:flutter_inappwebview_ios/example/pubspec.yaml`...
2025-12-30 16:15:41.107839 INFO: Running `git show origin/master:flutter_inappwebview_ios/pubspec.yaml`...
2025-12-30 16:15:41.114750 INFO: Running `git show origin/master:flutter_inappwebview_macos/example/pubspec.yaml`...
2025-12-30 16:15:41.121959 INFO: Running `git show origin/master:flutter_inappwebview_macos/pubspec.yaml`...
2025-12-30 16:15:41.128678 INFO: Running `git show origin/master:flutter_inappwebview_platform_interface/pubspec.yaml`...
2025-12-30 16:15:41.135497 INFO: Running `git show origin/master:flutter_inappwebview_web/example/pubspec.yaml`...
2025-12-30 16:15:41.141988 INFO: Running `git show origin/master:flutter_inappwebview_web/pubspec.yaml`...
2025-12-30 16:15:41.148390 INFO: Running `git show origin/master:flutter_inappwebview_windows/example/pubspec.yaml`...
2025-12-30 16:15:41.155503 INFO: Running `git show origin/master:flutter_inappwebview_windows/pubspec.yaml`...
2025-12-30 16:15:44.677181 INFO: Running `flutter --no-version-check packages pub get --no-example`...
2025-12-30 16:15:45.064161 INFO: Running `dart format --output=none --set-exit-if-changed /private/var/folders/x_/18wflq955xg_xq46dg740p5r0000gn/T/pana_gmcivC/flutter_inappwebview/lib`...
2025-12-30 16:15:46.830409 INFO: Analyzing pub downgrade...
2025-12-30 16:15:46.831898 INFO: Running `flutter --no-version-check packages pub downgrade --no-example`...
2025-12-30 16:15:47.530421 INFO: Running `dart analyze --format machine lib`...
2025-12-30 16:15:48.355406 INFO: [pub-downgrade-success]
2025-12-30 16:15:48.356970 INFO: Running `flutter --no-version-check packages pub upgrade --no-example`...

## ✓ Follow Dart file conventions (30 / 30)
### [*] 10/10 points: Provide a valid `pubspec.yaml`

### [*] 5/5 points: Provide a valid `README.md`

### [*] 5/5 points: Provide a valid `CHANGELOG.md`

### [*] 10/10 points: Use an OSI-approved license

Detected license: `Apache-2.0`.


## ✓ Provide documentation (10 / 10)
### [*] 10/10 points: Package has an example


## ✓ Platform support (20 / 20)
### [*] 20/20 points: Supports 5 of 6 possible platforms (**iOS**, **Android**, **Web**, **Windows**, **macOS**, Linux)

* ✓ Android

* ✓ iOS

* ✓ Windows

* ✓ macOS

* ✓ Web


These platforms are not supported:

<details>
<summary>
Package does not support platform `Linux`.
</summary>

Because:
* `package:flutter_inappwebview/flutter_inappwebview.dart` that declares support for platforms: `Android`, `iOS`, `Windows`, `macOS`, `Web`.
</details>


These issues are present but do not affect the score, because they may not originate in your package:

<details>
<summary>
Package not compatible with platform Web
</summary>

Because:
* `package:flutter_inappwebview/flutter_inappwebview.dart` that imports:
* `package:flutter_inappwebview/src/main.dart` that imports:
* `package:flutter_inappwebview/src/webview_environment/main.dart` that imports:
* `package:flutter_inappwebview/src/webview_environment/webview_environment.dart` that imports:
* `package:flutter_inappwebview_platform_interface/flutter_inappwebview_platform_interface.dart` that imports:
* `package:flutter_inappwebview_platform_interface/src/main.dart` that imports:
* `package:flutter_inappwebview_platform_interface/src/in_app_localhost_server.dart` that imports:
* `package:flutter_inappwebview_platform_interface/src/platform_in_app_localhost_server.dart` that imports:
* `dart:io`
</details>

### [x] 0/0 points: WASM compatibility

<details>
<summary>
Package not compatible with runtime wasm
</summary>

Because:
* `package:flutter_inappwebview/flutter_inappwebview.dart` that imports:
* `package:flutter_inappwebview/src/main.dart` that imports:
* `package:flutter_inappwebview/src/webview_environment/main.dart` that imports:
* `package:flutter_inappwebview/src/webview_environment/webview_environment.dart` that imports:
* `package:flutter_inappwebview_platform_interface/flutter_inappwebview_platform_interface.dart` that imports:
* `package:flutter_inappwebview_platform_interface/src/main.dart` that imports:
* `package:flutter_inappwebview_platform_interface/src/in_app_localhost_server.dart` that imports:
* `package:flutter_inappwebview_platform_interface/src/platform_in_app_localhost_server.dart` that imports:
* `dart:io`
</details>

This package is not compatible with runtime `wasm`, and will not be rewarded full points in a future version of the scoring model.

See https://dart.dev/web/wasm for details.


## ✗ Pass static analysis (30 / 50)
### [x] 30/50 points: code has no errors, warnings, lints, or formatting issues

Found 60 issues. Showing the first 2:

<details>
<summary>
WARNING: The value of the field '_webViewEnvironment' isn't used.
</summary>

`lib/src/cookie_manager.dart:40:23`

```
   ╷
40 │   WebViewEnvironment? _webViewEnvironment;
   │                       ^^^^^^^^^^^^^^^^^^^
   ╵
```

To reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `flutter analyze lib/src/cookie_manager.dart`
</details>

<details>
<summary>
INFO: Use 'const' with the constructor to improve performance.
</summary>

`lib/src/chrome_safari_browser/chrome_safari_browser.dart:19:11`

```
   ╷
19 │           PlatformChromeSafariBrowserCreationParams(),
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
```

To reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `flutter analyze lib/src/chrome_safari_browser/chrome_safari_browser.dart`
</details>


## ✓ Support up-to-date dependencies (40 / 40)
### [*] 10/10 points: All of the package dependencies are supported in the latest version

|Package|Constraint|Compatible|Latest|Notes|
|:-|:-|:-|:-|:-|
|[`flutter_inappwebview_android`]|`../flutter_inappwebview_android`|1.2.0-beta.3|1.2.0-beta.3||
|[`flutter_inappwebview_ios`]|`../flutter_inappwebview_ios`|1.2.0-beta.3|1.2.0-beta.3||
|[`flutter_inappwebview_macos`]|`../flutter_inappwebview_macos`|1.2.0-beta.3|1.2.0-beta.3||
|[`flutter_inappwebview_platform_interface`]|`../flutter_inappwebview_platform_interface`|1.4.0-beta.3|1.4.0-beta.3||
|[`flutter_inappwebview_web`]|`../flutter_inappwebview_web`|1.2.0-beta.3|1.2.0-beta.3||
|[`flutter_inappwebview_windows`]|`../flutter_inappwebview_windows`|0.7.0-beta.3|0.7.0-beta.3||

<details><summary>Transitive dependencies</summary>

|Package|Constraint|Compatible|Latest|Notes|
|:-|:-|:-|:-|:-|
|[`characters`]|-|1.4.0|1.4.1||
|[`collection`]|-|1.19.1|1.19.1||
|[`flutter_inappwebview_internal_annotations`]|-|1.3.0|1.3.0||
|[`material_color_utilities`]|-|0.11.1|0.13.0||
|[`meta`]|-|1.17.0|1.17.0||
|[`plugin_platform_interface`]|-|2.1.8|2.1.8||
|[`vector_math`]|-|2.2.0|2.2.0||
|[`web`]|-|1.1.1|1.1.1||
</details>

To reproduce run `dart pub outdated --no-dev-dependencies --up-to-date --no-dependency-overrides`.

[`flutter_inappwebview_android`]: https://pub.dev/packages/flutter_inappwebview_android
[`flutter_inappwebview_ios`]: https://pub.dev/packages/flutter_inappwebview_ios
[`flutter_inappwebview_macos`]: https://pub.dev/packages/flutter_inappwebview_macos
[`flutter_inappwebview_platform_interface`]: https://pub.dev/packages/flutter_inappwebview_platform_interface
[`flutter_inappwebview_web`]: https://pub.dev/packages/flutter_inappwebview_web
[`flutter_inappwebview_windows`]: https://pub.dev/packages/flutter_inappwebview_windows
[`characters`]: https://pub.dev/packages/characters
[`collection`]: https://pub.dev/packages/collection
[`flutter_inappwebview_internal_annotations`]: https://pub.dev/packages/flutter_inappwebview_internal_annotations
[`material_color_utilities`]: https://pub.dev/packages/material_color_utilities
[`meta`]: https://pub.dev/packages/meta
[`plugin_platform_interface`]: https://pub.dev/packages/plugin_platform_interface
[`vector_math`]: https://pub.dev/packages/vector_math
[`web`]: https://pub.dev/packages/web

### [*] 10/10 points: Package supports latest stable Dart and Flutter SDKs

### [*] 20/20 points: Compatible with dependency constraint lower bounds

`pub downgrade` does not expose any static analysis error.


Points: 130/150.
2025-12-30 16:15:49.206311 WARNING: Flutter SDK path was not specified, pana will use the default Dart SDK to run `dart analyze` on Flutter packages.
2025-12-30 16:15:49.211789 INFO: Running `dart --version`...
2025-12-30 16:15:49.257285 INFO: Running `flutter --no-version-check --version --machine`...
2025-12-30 16:15:49.545888 INFO: Running `git rev-parse --show-toplevel`...
2025-12-30 16:15:50.188807 INFO: Running `flutter --no-version-check pub pub get --no-example`...
2025-12-30 16:15:50.930733 INFO: Running `flutter --no-version-check pub pub get --no-example`...
2025-12-30 16:15:51.320287 INFO: Running `flutter --no-version-check pub pub outdated --json --up-to-date --no-dev-dependencies --no-dependency-overrides`...
2025-12-30 16:15:51.863771 INFO: Analyzing package...
2025-12-30 16:15:51.872582 INFO: Running `dart analyze --format machine lib`...
2025-12-30 16:15:54.320681 INFO: Running `git init`...
2025-12-30 16:15:54.331740 INFO: Running `git remote add origin https://github.com/pichillilorenzo/flutter_inappwebview`...
2025-12-30 16:15:54.339043 INFO: Running `git remote show origin`...
2025-12-30 16:15:54.825172 INFO: Running `git fetch --depth 1 --no-recurse-submodules origin master`...
2025-12-30 16:15:55.935146 INFO: Running `git ls-tree -r --name-only --full-tree origin/master`...
2025-12-30 16:15:55.948521 INFO: Running `git show origin/master:dev_packages/flutter_inappwebview_internal_annotations/pubspec.yaml`...
2025-12-30 16:15:55.958285 INFO: Running `git show origin/master:dev_packages/generators/pubspec.yaml`...
2025-12-30 16:15:55.966789 INFO: Running `git show origin/master:flutter_inappwebview/example/pubspec.yaml`...
2025-12-30 16:15:55.976955 INFO: Running `git show origin/master:flutter_inappwebview/pubspec.yaml`...
2025-12-30 16:15:55.988130 INFO: Running `git show origin/master:flutter_inappwebview_android/example/pubspec.yaml`...
2025-12-30 16:15:55.997931 INFO: Running `git show origin/master:flutter_inappwebview_android/pubspec.yaml`...
2025-12-30 16:15:56.007697 INFO: Running `git show origin/master:flutter_inappwebview_ios/example/pubspec.yaml`...
2025-12-30 16:15:56.016450 INFO: Running `git show origin/master:flutter_inappwebview_ios/pubspec.yaml`...
2025-12-30 16:15:56.024740 INFO: Running `git show origin/master:flutter_inappwebview_macos/example/pubspec.yaml`...
2025-12-30 16:15:56.032637 INFO: Running `git show origin/master:flutter_inappwebview_macos/pubspec.yaml`...
2025-12-30 16:15:56.040787 INFO: Running `git show origin/master:flutter_inappwebview_platform_interface/pubspec.yaml`...
2025-12-30 16:15:56.048752 INFO: Running `git show origin/master:flutter_inappwebview_web/example/pubspec.yaml`...
2025-12-30 16:15:56.058476 INFO: Running `git show origin/master:flutter_inappwebview_web/pubspec.yaml`...
2025-12-30 16:15:56.069782 INFO: Running `git show origin/master:flutter_inappwebview_windows/example/pubspec.yaml`...
2025-12-30 16:15:56.079078 INFO: Running `git show origin/master:flutter_inappwebview_windows/pubspec.yaml`...
2025-12-30 16:15:59.674617 INFO: Running `flutter --no-version-check packages pub get --no-example`...
2025-12-30 16:16:00.099139 INFO: Running `dart format --output=none --set-exit-if-changed /private/var/folders/x_/18wflq955xg_xq46dg740p5r0000gn/T/pana_a66z1x/flutter_inappwebview_macos/lib`...
2025-12-30 16:16:00.235112 INFO: Analyzing pub downgrade...
2025-12-30 16:16:00.236549 INFO: Running `flutter --no-version-check packages pub downgrade --no-example`...
2025-12-30 16:16:01.070013 INFO: Running `dart analyze --format machine lib`...
2025-12-30 16:16:01.727485 INFO: [pub-downgrade-success]
2025-12-30 16:16:01.729116 INFO: Running `flutter --no-version-check packages pub upgrade --no-example`...

## ✓ Follow Dart file conventions (30 / 30)
### [*] 10/10 points: Provide a valid `pubspec.yaml`

### [*] 5/5 points: Provide a valid `README.md`

### [*] 5/5 points: Provide a valid `CHANGELOG.md`

### [*] 10/10 points: Use an OSI-approved license

Detected license: `Apache-2.0`.


## ✓ Provide documentation (10 / 10)
### [*] 10/10 points: Package has an example


## ✓ Platform support (20 / 20)
### [*] 20/20 points: Supports 1 of 6 possible platforms (iOS, Android, Web, Windows, **macOS**, Linux)

* ✓ macOS


These platforms are not supported:

<details>
<summary>
Package does not support platform `Android`.
</summary>

Because:
* `package:flutter_inappwebview_macos/flutter_inappwebview_macos.dart` that declares support for platforms: `macOS`.
</details>

<details>
<summary>
Package does not support platform `iOS`.
</summary>

Because:
* `package:flutter_inappwebview_macos/flutter_inappwebview_macos.dart` that declares support for platforms: `macOS`.
</details>

<details>
<summary>
Package does not support platform `Windows`.
</summary>

Because:
* `package:flutter_inappwebview_macos/flutter_inappwebview_macos.dart` that declares support for platforms: `macOS`.
</details>

<details>
<summary>
Package does not support platform `Linux`.
</summary>

Because:
* `package:flutter_inappwebview_macos/flutter_inappwebview_macos.dart` that declares support for platforms: `macOS`.
</details>

<details>
<summary>
Package does not support platform `Web`.
</summary>

Because:
* `package:flutter_inappwebview_macos/flutter_inappwebview_macos.dart` that declares support for platforms: `macOS`.
</details>

### [x] 0/0 points: Swift Package Manager support

<details>
<summary>
Package does not support the Swift Package Manager on macOS
</summary>

It does not contain `macos/flutter_inappwebview_macos/Package.swift`.

</details>

This package for iOS or macOS does not support the Swift Package Manager. It will not receive full points in a future version of the scoring model.

See https://docs.flutter.dev/to/spm for details.


## ✗ Pass static analysis (40 / 50)
### [~] 40/50 points: code has no errors, warnings, lints, or formatting issues

Found 230 issues. Showing the first 2:

<details>
<summary>
INFO: Use 'const' with the constructor to improve performance.
</summary>

`lib/src/cookie_manager.dart:50:7`

```
   ╷
50 │       MacOSCookieManagerCreationParams(PlatformCookieManagerCreationParams()));
   │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
```

To reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `flutter analyze lib/src/cookie_manager.dart`
</details>

<details>
<summary>
INFO: Use 'const' with the constructor to improve performance.
</summary>

`lib/src/cookie_manager.dart:50:40`

```
   ╷
50 │       MacOSCookieManagerCreationParams(PlatformCookieManagerCreationParams()));
   │                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
```

To reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `flutter analyze lib/src/cookie_manager.dart`
</details>


## ✓ Support up-to-date dependencies (40 / 40)
### [*] 10/10 points: All of the package dependencies are supported in the latest version

|Package|Constraint|Compatible|Latest|Notes|
|:-|:-|:-|:-|:-|
|[`flutter_inappwebview_platform_interface`]|`../flutter_inappwebview_platform_interface`|1.4.0-beta.3|1.4.0-beta.3||

<details><summary>Transitive dependencies</summary>

|Package|Constraint|Compatible|Latest|Notes|
|:-|:-|:-|:-|:-|
|[`characters`]|-|1.4.0|1.4.1||
|[`collection`]|-|1.19.1|1.19.1||
|[`flutter_inappwebview_internal_annotations`]|-|1.3.0|1.3.0||
|[`material_color_utilities`]|-|0.11.1|0.13.0||
|[`meta`]|-|1.17.0|1.17.0||
|[`plugin_platform_interface`]|-|2.1.8|2.1.8||
|[`vector_math`]|-|2.2.0|2.2.0||
</details>

To reproduce run `dart pub outdated --no-dev-dependencies --up-to-date --no-dependency-overrides`.

[`flutter_inappwebview_platform_interface`]: https://pub.dev/packages/flutter_inappwebview_platform_interface
[`characters`]: https://pub.dev/packages/characters
[`collection`]: https://pub.dev/packages/collection
[`flutter_inappwebview_internal_annotations`]: https://pub.dev/packages/flutter_inappwebview_internal_annotations
[`material_color_utilities`]: https://pub.dev/packages/material_color_utilities
[`meta`]: https://pub.dev/packages/meta
[`plugin_platform_interface`]: https://pub.dev/packages/plugin_platform_interface
[`vector_math`]: https://pub.dev/packages/vector_math

### [*] 10/10 points: Package supports latest stable Dart and Flutter SDKs

### [*] 20/20 points: Compatible with dependency constraint lower bounds

`pub downgrade` does not expose any static analysis error.


Points: 140/150.
2025-12-30 16:16:02.572150 WARNING: Flutter SDK path was not specified, pana will use the default Dart SDK to run `dart analyze` on Flutter packages.
2025-12-30 16:16:02.577544 INFO: Running `dart --version`...
2025-12-30 16:16:02.622922 INFO: Running `flutter --no-version-check --version --machine`...
2025-12-30 16:16:02.907049 INFO: Running `git rev-parse --show-toplevel`...
2025-12-30 16:16:03.548011 INFO: Running `flutter --no-version-check pub pub get --no-example`...
2025-12-30 16:16:04.348668 INFO: Running `flutter --no-version-check pub pub get --no-example`...
2025-12-30 16:16:04.751211 INFO: Running `flutter --no-version-check pub pub outdated --json --up-to-date --no-dev-dependencies --no-dependency-overrides`...
2025-12-30 16:16:05.344772 INFO: Analyzing package...
2025-12-30 16:16:05.353547 INFO: Running `dart analyze --format machine lib`...
2025-12-30 16:16:07.761444 INFO: Running `git init`...
2025-12-30 16:16:07.772132 INFO: Running `git remote add origin https://github.com/pichillilorenzo/flutter_inappwebview`...
2025-12-30 16:16:07.779424 INFO: Running `git remote show origin`...
2025-12-30 16:16:08.261729 INFO: Running `git fetch --depth 1 --no-recurse-submodules origin master`...
2025-12-30 16:16:09.305702 INFO: Running `git ls-tree -r --name-only --full-tree origin/master`...
2025-12-30 16:16:09.316969 INFO: Running `git show origin/master:dev_packages/flutter_inappwebview_internal_annotations/pubspec.yaml`...
2025-12-30 16:16:09.324354 INFO: Running `git show origin/master:dev_packages/generators/pubspec.yaml`...
2025-12-30 16:16:09.331021 INFO: Running `git show origin/master:flutter_inappwebview/example/pubspec.yaml`...
2025-12-30 16:16:09.339278 INFO: Running `git show origin/master:flutter_inappwebview/pubspec.yaml`...
2025-12-30 16:16:09.347520 INFO: Running `git show origin/master:flutter_inappwebview_android/example/pubspec.yaml`...
2025-12-30 16:16:09.355332 INFO: Running `git show origin/master:flutter_inappwebview_android/pubspec.yaml`...
2025-12-30 16:16:09.363247 INFO: Running `git show origin/master:flutter_inappwebview_ios/example/pubspec.yaml`...
2025-12-30 16:16:09.370540 INFO: Running `git show origin/master:flutter_inappwebview_ios/pubspec.yaml`...
2025-12-30 16:16:09.378166 INFO: Running `git show origin/master:flutter_inappwebview_macos/example/pubspec.yaml`...
2025-12-30 16:16:09.385040 INFO: Running `git show origin/master:flutter_inappwebview_macos/pubspec.yaml`...
2025-12-30 16:16:09.392209 INFO: Running `git show origin/master:flutter_inappwebview_platform_interface/pubspec.yaml`...
2025-12-30 16:16:09.399202 INFO: Running `git show origin/master:flutter_inappwebview_web/example/pubspec.yaml`...
2025-12-30 16:16:09.405996 INFO: Running `git show origin/master:flutter_inappwebview_web/pubspec.yaml`...
2025-12-30 16:16:09.412801 INFO: Running `git show origin/master:flutter_inappwebview_windows/example/pubspec.yaml`...
2025-12-30 16:16:09.419111 INFO: Running `git show origin/master:flutter_inappwebview_windows/pubspec.yaml`...
2025-12-30 16:16:14.571061 INFO: Running `flutter --no-version-check packages pub get --no-example`...
2025-12-30 16:16:14.951957 INFO: Running `dart format --output=none --set-exit-if-changed /private/var/folders/x_/18wflq955xg_xq46dg740p5r0000gn/T/pana_159ruU/flutter_inappwebview_windows/lib`...
2025-12-30 16:16:15.100014 INFO: Analyzing pub downgrade...
2025-12-30 16:16:15.101555 INFO: Running `flutter --no-version-check packages pub downgrade --no-example`...
2025-12-30 16:16:15.659116 INFO: Running `dart analyze --format machine lib`...
2025-12-30 16:16:16.323348 INFO: [pub-downgrade-success]
2025-12-30 16:16:16.325228 INFO: Running `flutter --no-version-check packages pub upgrade --no-example`...

## ✓ Follow Dart file conventions (30 / 30)
### [*] 10/10 points: Provide a valid `pubspec.yaml`

### [*] 5/5 points: Provide a valid `README.md`

### [*] 5/5 points: Provide a valid `CHANGELOG.md`

### [*] 10/10 points: Use an OSI-approved license

Detected license: `Apache-2.0`.


## ✓ Provide documentation (10 / 10)
### [*] 10/10 points: Package has an example


## ✓ Platform support (20 / 20)
### [*] 20/20 points: Supports 1 of 6 possible platforms (iOS, Android, Web, **Windows**, macOS, Linux)

* ✓ Windows


These platforms are not supported:

<details>
<summary>
Package does not support platform `Android`.
</summary>

Because:
* `package:flutter_inappwebview_windows/flutter_inappwebview_windows.dart` that declares support for platforms: `Windows`.
</details>

<details>
<summary>
Package does not support platform `iOS`.
</summary>

Because:
* `package:flutter_inappwebview_windows/flutter_inappwebview_windows.dart` that declares support for platforms: `Windows`.
</details>

<details>
<summary>
Package does not support platform `Linux`.
</summary>

Because:
* `package:flutter_inappwebview_windows/flutter_inappwebview_windows.dart` that declares support for platforms: `Windows`.
</details>

<details>
<summary>
Package does not support platform `macOS`.
</summary>

Because:
* `package:flutter_inappwebview_windows/flutter_inappwebview_windows.dart` that declares support for platforms: `Windows`.
</details>

<details>
<summary>
Package does not support platform `Web`.
</summary>

Because:
* `package:flutter_inappwebview_windows/flutter_inappwebview_windows.dart` that declares support for platforms: `Windows`.
</details>


## ✗ Pass static analysis (30 / 50)
### [x] 30/50 points: code has no errors, warnings, lints, or formatting issues

Found 221 issues. Showing the first 2:

<details>
<summary>
WARNING: The value of the local variable 'pullToRefreshSettings' isn't used.
</summary>

`lib/src/in_app_webview/in_app_webview.dart:306:26`

```
    ╷
306 │     Map<String, dynamic> pullToRefreshSettings =
    │                          ^^^^^^^^^^^^^^^^^^^^^
    ╵
```

To reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `flutter analyze lib/src/in_app_webview/in_app_webview.dart`
</details>

<details>
<summary>
WARNING: The declaration '_PlatformWebMessagePort.static' isn't referenced.
</summary>

`lib/src/inappwebview_platform.dart:475:35`

```
    ╷
475 │   factory _PlatformWebMessagePort.static() => _staticValue;
    │                                   ^^^^^^
    ╵
```

To reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `flutter analyze lib/src/inappwebview_platform.dart`
</details>


## ✓ Support up-to-date dependencies (40 / 40)
### [*] 10/10 points: All of the package dependencies are supported in the latest version

|Package|Constraint|Compatible|Latest|Notes|
|:-|:-|:-|:-|:-|
|[`flutter_inappwebview_platform_interface`]|`../flutter_inappwebview_platform_interface`|1.4.0-beta.3|1.4.0-beta.3||

<details><summary>Transitive dependencies</summary>

|Package|Constraint|Compatible|Latest|Notes|
|:-|:-|:-|:-|:-|
|[`characters`]|-|1.4.0|1.4.1||
|[`collection`]|-|1.19.1|1.19.1||
|[`flutter_inappwebview_internal_annotations`]|-|1.3.0|1.3.0||
|[`material_color_utilities`]|-|0.11.1|0.13.0||
|[`meta`]|-|1.17.0|1.17.0||
|[`plugin_platform_interface`]|-|2.1.8|2.1.8||
|[`vector_math`]|-|2.2.0|2.2.0||
</details>

To reproduce run `dart pub outdated --no-dev-dependencies --up-to-date --no-dependency-overrides`.

[`flutter_inappwebview_platform_interface`]: https://pub.dev/packages/flutter_inappwebview_platform_interface
[`characters`]: https://pub.dev/packages/characters
[`collection`]: https://pub.dev/packages/collection
[`flutter_inappwebview_internal_annotations`]: https://pub.dev/packages/flutter_inappwebview_internal_annotations
[`material_color_utilities`]: https://pub.dev/packages/material_color_utilities
[`meta`]: https://pub.dev/packages/meta
[`plugin_platform_interface`]: https://pub.dev/packages/plugin_platform_interface
[`vector_math`]: https://pub.dev/packages/vector_math

### [*] 10/10 points: Package supports latest stable Dart and Flutter SDKs

### [*] 20/20 points: Compatible with dependency constraint lower bounds

`pub downgrade` does not expose any static analysis error.


Points: 130/150.
2025-12-30 16:16:17.150775 WARNING: Flutter SDK path was not specified, pana will use the default Dart SDK to run `dart analyze` on Flutter packages.
2025-12-30 16:16:17.156214 INFO: Running `dart --version`...
2025-12-30 16:16:17.201585 INFO: Running `flutter --no-version-check --version --machine`...
2025-12-30 16:16:17.489538 INFO: Running `git rev-parse --show-toplevel`...
2025-12-30 16:16:18.117371 INFO: Running `flutter --no-version-check pub pub get --no-example`...
2025-12-30 16:16:19.007157 INFO: Running `flutter --no-version-check pub pub get --no-example`...
2025-12-30 16:16:19.386455 INFO: Running `flutter --no-version-check pub pub outdated --json --up-to-date --no-dev-dependencies --no-dependency-overrides`...
2025-12-30 16:16:19.970316 INFO: Analyzing package...
2025-12-30 16:16:19.979515 INFO: Running `dart analyze --format machine lib`...
2025-12-30 16:16:22.449197 INFO: Running `git init`...
2025-12-30 16:16:22.462336 INFO: Running `git remote add origin https://github.com/pichillilorenzo/flutter_inappwebview`...
2025-12-30 16:16:22.472753 INFO: Running `git remote show origin`...
2025-12-30 16:16:22.959344 INFO: Running `git fetch --depth 1 --no-recurse-submodules origin master`...
2025-12-30 16:16:24.117917 INFO: Running `git ls-tree -r --name-only --full-tree origin/master`...
2025-12-30 16:16:24.130437 INFO: Running `git show origin/master:dev_packages/flutter_inappwebview_internal_annotations/pubspec.yaml`...
2025-12-30 16:16:24.138186 INFO: Running `git show origin/master:dev_packages/generators/pubspec.yaml`...
2025-12-30 16:16:24.145122 INFO: Running `git show origin/master:flutter_inappwebview/example/pubspec.yaml`...
2025-12-30 16:16:24.153503 INFO: Running `git show origin/master:flutter_inappwebview/pubspec.yaml`...
2025-12-30 16:16:24.161925 INFO: Running `git show origin/master:flutter_inappwebview_android/example/pubspec.yaml`...
2025-12-30 16:16:24.169727 INFO: Running `git show origin/master:flutter_inappwebview_android/pubspec.yaml`...
2025-12-30 16:16:24.177827 INFO: Running `git show origin/master:flutter_inappwebview_ios/example/pubspec.yaml`...
2025-12-30 16:16:24.184964 INFO: Running `git show origin/master:flutter_inappwebview_ios/pubspec.yaml`...
2025-12-30 16:16:24.192582 INFO: Running `git show origin/master:flutter_inappwebview_macos/example/pubspec.yaml`...
2025-12-30 16:16:24.199805 INFO: Running `git show origin/master:flutter_inappwebview_macos/pubspec.yaml`...
2025-12-30 16:16:24.206982 INFO: Running `git show origin/master:flutter_inappwebview_platform_interface/pubspec.yaml`...
2025-12-30 16:16:24.214185 INFO: Running `git show origin/master:flutter_inappwebview_web/example/pubspec.yaml`...
2025-12-30 16:16:24.220859 INFO: Running `git show origin/master:flutter_inappwebview_web/pubspec.yaml`...
2025-12-30 16:16:24.227733 INFO: Running `git show origin/master:flutter_inappwebview_windows/example/pubspec.yaml`...
2025-12-30 16:16:24.234390 INFO: Running `git show origin/master:flutter_inappwebview_windows/pubspec.yaml`...
2025-12-30 16:16:26.951676 INFO: Running `flutter --no-version-check packages pub get --no-example`...
2025-12-30 16:16:27.410967 INFO: Running `dart format --output=none --set-exit-if-changed /private/var/folders/x_/18wflq955xg_xq46dg740p5r0000gn/T/pana_1AgzoO/flutter_inappwebview_android/lib`...
2025-12-30 16:16:27.556785 INFO: Analyzing pub downgrade...
2025-12-30 16:16:27.558363 INFO: Running `flutter --no-version-check packages pub downgrade --no-example`...
2025-12-30 16:16:28.131904 INFO: Running `dart analyze --format machine lib`...
2025-12-30 16:16:28.817520 INFO: [pub-downgrade-success]
2025-12-30 16:16:28.819288 INFO: Running `flutter --no-version-check packages pub upgrade --no-example`...

## ✓ Follow Dart file conventions (30 / 30)
### [*] 10/10 points: Provide a valid `pubspec.yaml`

### [*] 5/5 points: Provide a valid `README.md`

### [*] 5/5 points: Provide a valid `CHANGELOG.md`

### [*] 10/10 points: Use an OSI-approved license

Detected license: `Apache-2.0`.


## ✓ Provide documentation (10 / 10)
### [*] 10/10 points: Package has an example


## ✓ Platform support (20 / 20)
### [*] 20/20 points: Supports 1 of 6 possible platforms (iOS, **Android**, Web, Windows, macOS, Linux)

* ✓ Android


These platforms are not supported:

<details>
<summary>
Package does not support platform `iOS`.
</summary>

Because:
* `package:flutter_inappwebview_android/flutter_inappwebview_android.dart` that declares support for platforms: `Android`.
</details>

<details>
<summary>
Package does not support platform `Windows`.
</summary>

Because:
* `package:flutter_inappwebview_android/flutter_inappwebview_android.dart` that declares support for platforms: `Android`.
</details>

<details>
<summary>
Package does not support platform `Linux`.
</summary>

Because:
* `package:flutter_inappwebview_android/flutter_inappwebview_android.dart` that declares support for platforms: `Android`.
</details>

<details>
<summary>
Package does not support platform `macOS`.
</summary>

Because:
* `package:flutter_inappwebview_android/flutter_inappwebview_android.dart` that declares support for platforms: `Android`.
</details>

<details>
<summary>
Package does not support platform `Web`.
</summary>

Because:
* `package:flutter_inappwebview_android/flutter_inappwebview_android.dart` that declares support for platforms: `Android`.
</details>


## ✗ Pass static analysis (40 / 50)
### [~] 40/50 points: code has no errors, warnings, lints, or formatting issues

Found 256 issues. Showing the first 2:

<details>
<summary>
INFO: Use 'const' with the constructor to improve performance.
</summary>

`lib/src/chrome_safari_browser/chrome_safari_browser.dart:25:12`

```
   ╷
25 │     return AndroidChromeSafariBrowserCreationParams();
   │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
```

To reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `flutter analyze lib/src/chrome_safari_browser/chrome_safari_browser.dart`
</details>

<details>
<summary>
INFO: Use 'const' with the constructor to improve performance.
</summary>

`lib/src/chrome_safari_browser/chrome_safari_browser.dart:45:34`

```
   ╷
45 │       AndroidChromeSafariBrowser(AndroidChromeSafariBrowserCreationParams());
   │                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
```

To reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `flutter analyze lib/src/chrome_safari_browser/chrome_safari_browser.dart`
</details>


## ✓ Support up-to-date dependencies (40 / 40)
### [*] 10/10 points: All of the package dependencies are supported in the latest version

|Package|Constraint|Compatible|Latest|Notes|
|:-|:-|:-|:-|:-|
|[`flutter_inappwebview_platform_interface`]|`../flutter_inappwebview_platform_interface`|1.4.0-beta.3|1.4.0-beta.3||

<details><summary>Transitive dependencies</summary>

|Package|Constraint|Compatible|Latest|Notes|
|:-|:-|:-|:-|:-|
|[`characters`]|-|1.4.0|1.4.1||
|[`collection`]|-|1.19.1|1.19.1||
|[`flutter_inappwebview_internal_annotations`]|-|1.3.0|1.3.0||
|[`material_color_utilities`]|-|0.11.1|0.13.0||
|[`meta`]|-|1.17.0|1.17.0||
|[`plugin_platform_interface`]|-|2.1.8|2.1.8||
|[`vector_math`]|-|2.2.0|2.2.0||
</details>

To reproduce run `dart pub outdated --no-dev-dependencies --up-to-date --no-dependency-overrides`.

[`flutter_inappwebview_platform_interface`]: https://pub.dev/packages/flutter_inappwebview_platform_interface
[`characters`]: https://pub.dev/packages/characters
[`collection`]: https://pub.dev/packages/collection
[`flutter_inappwebview_internal_annotations`]: https://pub.dev/packages/flutter_inappwebview_internal_annotations
[`material_color_utilities`]: https://pub.dev/packages/material_color_utilities
[`meta`]: https://pub.dev/packages/meta
[`plugin_platform_interface`]: https://pub.dev/packages/plugin_platform_interface
[`vector_math`]: https://pub.dev/packages/vector_math

### [*] 10/10 points: Package supports latest stable Dart and Flutter SDKs

### [*] 20/20 points: Compatible with dependency constraint lower bounds

`pub downgrade` does not expose any static analysis error.


Points: 140/150.
2025-12-30 16:16:29.665235 WARNING: Flutter SDK path was not specified, pana will use the default Dart SDK to run `dart analyze` on Flutter packages.
2025-12-30 16:16:29.670914 INFO: Running `dart --version`...
2025-12-30 16:16:29.717171 INFO: Running `flutter --no-version-check --version --machine`...
2025-12-30 16:16:30.008853 INFO: Running `git rev-parse --show-toplevel`...
2025-12-30 16:16:30.636938 INFO: Running `flutter --no-version-check pub pub get --no-example`...
2025-12-30 16:16:31.656018 INFO: Running `flutter --no-version-check pub pub get --no-example`...
2025-12-30 16:16:32.036384 INFO: Running `flutter --no-version-check pub pub outdated --json --up-to-date --no-dev-dependencies --no-dependency-overrides`...
2025-12-30 16:16:32.613914 INFO: Analyzing package...
2025-12-30 16:16:32.622034 INFO: Running `dart analyze --format machine lib`...
2025-12-30 16:16:35.812969 INFO: Running `git init`...
2025-12-30 16:16:35.824759 INFO: Running `git remote add origin https://github.com/pichillilorenzo/flutter_inappwebview`...
2025-12-30 16:16:35.832264 INFO: Running `git remote show origin`...
2025-12-30 16:16:36.321473 INFO: Running `git fetch --depth 1 --no-recurse-submodules origin master`...
2025-12-30 16:16:37.417579 INFO: Running `git ls-tree -r --name-only --full-tree origin/master`...
2025-12-30 16:16:37.428029 INFO: Running `git show origin/master:dev_packages/flutter_inappwebview_internal_annotations/pubspec.yaml`...
2025-12-30 16:16:37.435715 INFO: Running `git show origin/master:dev_packages/generators/pubspec.yaml`...
2025-12-30 16:16:37.442906 INFO: Running `git show origin/master:flutter_inappwebview/example/pubspec.yaml`...
2025-12-30 16:16:37.451203 INFO: Running `git show origin/master:flutter_inappwebview/pubspec.yaml`...
2025-12-30 16:16:37.459871 INFO: Running `git show origin/master:flutter_inappwebview_android/example/pubspec.yaml`...
2025-12-30 16:16:37.467746 INFO: Running `git show origin/master:flutter_inappwebview_android/pubspec.yaml`...
2025-12-30 16:16:37.475257 INFO: Running `git show origin/master:flutter_inappwebview_ios/example/pubspec.yaml`...
2025-12-30 16:16:37.483178 INFO: Running `git show origin/master:flutter_inappwebview_ios/pubspec.yaml`...
2025-12-30 16:16:37.491206 INFO: Running `git show origin/master:flutter_inappwebview_macos/example/pubspec.yaml`...
2025-12-30 16:16:37.498538 INFO: Running `git show origin/master:flutter_inappwebview_macos/pubspec.yaml`...
2025-12-30 16:16:37.506095 INFO: Running `git show origin/master:flutter_inappwebview_platform_interface/pubspec.yaml`...
2025-12-30 16:16:37.513618 INFO: Running `git show origin/master:flutter_inappwebview_web/example/pubspec.yaml`...
2025-12-30 16:16:37.520572 INFO: Running `git show origin/master:flutter_inappwebview_web/pubspec.yaml`...
2025-12-30 16:16:37.527559 INFO: Running `git show origin/master:flutter_inappwebview_windows/example/pubspec.yaml`...
2025-12-30 16:16:37.534277 INFO: Running `git show origin/master:flutter_inappwebview_windows/pubspec.yaml`...
2025-12-30 16:16:41.746079 INFO: Running `flutter --no-version-check packages pub get --no-example`...
2025-12-30 16:16:42.197863 INFO: Running `dart format --output=none --set-exit-if-changed /private/var/folders/x_/18wflq955xg_xq46dg740p5r0000gn/T/pana_3AM4CU/flutter_inappwebview_platform_interface/lib`...
2025-12-30 16:16:42.720126 INFO: Analyzing pub downgrade...
2025-12-30 16:16:42.721523 INFO: Running `flutter --no-version-check packages pub downgrade --no-example`...
2025-12-30 16:16:43.183986 INFO: Running `dart analyze --format machine lib`...
2025-12-30 16:16:43.905166 INFO: [pub-downgrade-success]
2025-12-30 16:16:43.906783 INFO: Running `flutter --no-version-check packages pub upgrade --no-example`...

## ✓ Follow Dart file conventions (30 / 30)
### [*] 10/10 points: Provide a valid `pubspec.yaml`

### [*] 5/5 points: Provide a valid `README.md`

### [*] 5/5 points: Provide a valid `CHANGELOG.md`

### [*] 10/10 points: Use an OSI-approved license

Detected license: `Apache-2.0`.


## ✗ Provide documentation (0 / 10)
### [x] 0/10 points: Package has an example

<details>
<summary>
No example found.
</summary>

See [package layout](https://dart.dev/tools/pub/package-layout#examples) guidelines on how to add an example.
</details>


## ✓ Platform support (20 / 20)
### [*] 20/20 points: Supports 5 of 6 possible platforms (**iOS**, **Android**, Web, **Windows**, **macOS**, **Linux**)

* ✓ Android

* ✓ iOS

* ✓ Windows

* ✓ Linux

* ✓ macOS


These platforms are not supported:

<details>
<summary>
Package not compatible with platform Web
</summary>

Because:
* `package:flutter_inappwebview_platform_interface/flutter_inappwebview_platform_interface.dart` that imports:
* `package:flutter_inappwebview_platform_interface/src/main.dart` that imports:
* `package:flutter_inappwebview_platform_interface/src/in_app_localhost_server.dart` that imports:
* `package:flutter_inappwebview_platform_interface/src/platform_in_app_localhost_server.dart` that imports:
* `dart:io`
</details>


## ✗ Pass static analysis (30 / 50)
### [x] 30/50 points: code has no errors, warnings, lints, or formatting issues

Found 2226 issues. Showing the first 2:

<details>
<summary>
WARNING: A value for optional parameter 'enumMethod' isn't ever given.
</summary>

`lib/src/context_menu/context_menu_item.dart:51:53`

```
   ╷
51 │   Map<String, dynamic> _toMapMergeWith({EnumMethod? enumMethod}) {
   │                                                     ^^^^^^^^^^
   ╵
```

To reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `flutter analyze lib/src/context_menu/context_menu_item.dart`
</details>

<details>
<summary>
WARNING: The declaration 'isClassSupported' isn't referenced.
</summary>

`lib/src/find_interaction/platform_find_interaction_controller.g.dart:76:15`

```
   ╷
76 │   static bool isClassSupported({TargetPlatform? platform}) {
   │               ^^^^^^^^^^^^^^^^
   ╵
```

To reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `flutter analyze lib/src/find_interaction/platform_find_interaction_controller.g.dart`
</details>


## ✓ Support up-to-date dependencies (40 / 40)
### [*] 10/10 points: All of the package dependencies are supported in the latest version

|Package|Constraint|Compatible|Latest|Notes|
|:-|:-|:-|:-|:-|
|[`flutter_inappwebview_internal_annotations`]|`../dev_packages/flutter_inappwebview_internal_annotations`|1.3.0|1.3.0||
|[`plugin_platform_interface`]|`^2.1.8`|2.1.8|2.1.8||

<details><summary>Transitive dependencies</summary>

|Package|Constraint|Compatible|Latest|Notes|
|:-|:-|:-|:-|:-|
|[`characters`]|-|1.4.0|1.4.1||
|[`collection`]|-|1.19.1|1.19.1||
|[`material_color_utilities`]|-|0.11.1|0.13.0||
|[`meta`]|-|1.17.0|1.17.0||
|[`vector_math`]|-|2.2.0|2.2.0||
</details>

To reproduce run `dart pub outdated --no-dev-dependencies --up-to-date --no-dependency-overrides`.

[`flutter_inappwebview_internal_annotations`]: https://pub.dev/packages/flutter_inappwebview_internal_annotations
[`plugin_platform_interface`]: https://pub.dev/packages/plugin_platform_interface
[`characters`]: https://pub.dev/packages/characters
[`collection`]: https://pub.dev/packages/collection
[`material_color_utilities`]: https://pub.dev/packages/material_color_utilities
[`meta`]: https://pub.dev/packages/meta
[`vector_math`]: https://pub.dev/packages/vector_math

### [*] 10/10 points: Package supports latest stable Dart and Flutter SDKs

### [*] 20/20 points: Compatible with dependency constraint lower bounds

`pub downgrade` does not expose any static analysis error.


Points: 120/150.
2025-12-30 16:16:44.679369 WARNING: Flutter SDK path was not specified, pana will use the default Dart SDK to run `dart analyze` on Flutter packages.
2025-12-30 16:16:44.684913 INFO: Running `dart --version`...
2025-12-30 16:16:44.729575 INFO: Running `flutter --no-version-check --version --machine`...
2025-12-30 16:16:44.998788 INFO: Running `git rev-parse --show-toplevel`...
2025-12-30 16:16:45.631919 INFO: Running `flutter --no-version-check pub pub get --no-example`...
2025-12-30 16:16:46.615700 INFO: Running `flutter --no-version-check pub pub get --no-example`...
2025-12-30 16:16:47.099467 INFO: Running `flutter --no-version-check pub pub outdated --json --up-to-date --no-dev-dependencies --no-dependency-overrides`...
2025-12-30 16:16:47.702803 INFO: Analyzing package...
2025-12-30 16:16:47.711696 INFO: Running `dart analyze --format machine lib`...
2025-12-30 16:16:50.134164 INFO: Running `git init`...
2025-12-30 16:16:50.145966 INFO: Running `git remote add origin https://github.com/pichillilorenzo/flutter_inappwebview`...
2025-12-30 16:16:50.153213 INFO: Running `git remote show origin`...
2025-12-30 16:16:52.034115 INFO: Running `git fetch --depth 1 --no-recurse-submodules origin master`...
2025-12-30 16:16:53.505066 INFO: Running `git ls-tree -r --name-only --full-tree origin/master`...
2025-12-30 16:16:53.517002 INFO: Running `git show origin/master:dev_packages/flutter_inappwebview_internal_annotations/pubspec.yaml`...
2025-12-30 16:16:53.524822 INFO: Running `git show origin/master:dev_packages/generators/pubspec.yaml`...
2025-12-30 16:16:53.532147 INFO: Running `git show origin/master:flutter_inappwebview/example/pubspec.yaml`...
2025-12-30 16:16:53.540523 INFO: Running `git show origin/master:flutter_inappwebview/pubspec.yaml`...
2025-12-30 16:16:53.549691 INFO: Running `git show origin/master:flutter_inappwebview_android/example/pubspec.yaml`...
2025-12-30 16:16:53.557534 INFO: Running `git show origin/master:flutter_inappwebview_android/pubspec.yaml`...
2025-12-30 16:16:53.565755 INFO: Running `git show origin/master:flutter_inappwebview_ios/example/pubspec.yaml`...
2025-12-30 16:16:53.572968 INFO: Running `git show origin/master:flutter_inappwebview_ios/pubspec.yaml`...
2025-12-30 16:16:53.581823 INFO: Running `git show origin/master:flutter_inappwebview_macos/example/pubspec.yaml`...
2025-12-30 16:16:53.589630 INFO: Running `git show origin/master:flutter_inappwebview_macos/pubspec.yaml`...
2025-12-30 16:16:53.596793 INFO: Running `git show origin/master:flutter_inappwebview_platform_interface/pubspec.yaml`...
2025-12-30 16:16:53.603815 INFO: Running `git show origin/master:flutter_inappwebview_web/example/pubspec.yaml`...
2025-12-30 16:16:53.610399 INFO: Running `git show origin/master:flutter_inappwebview_web/pubspec.yaml`...
2025-12-30 16:16:53.617275 INFO: Running `git show origin/master:flutter_inappwebview_windows/example/pubspec.yaml`...
2025-12-30 16:16:53.623667 INFO: Running `git show origin/master:flutter_inappwebview_windows/pubspec.yaml`...
2025-12-30 16:16:57.494820 INFO: Running `flutter --no-version-check packages pub get --no-example`...
2025-12-30 16:16:57.887567 INFO: Running `dart format --output=none --set-exit-if-changed /private/var/folders/x_/18wflq955xg_xq46dg740p5r0000gn/T/pana_9GuaOh/flutter_inappwebview_ios/lib`...
2025-12-30 16:16:58.032212 INFO: Analyzing pub downgrade...
2025-12-30 16:16:58.033745 INFO: Running `flutter --no-version-check packages pub downgrade --no-example`...
2025-12-30 16:16:58.714048 INFO: Running `dart analyze --format machine lib`...
2025-12-30 16:16:59.369302 INFO: [pub-downgrade-success]
2025-12-30 16:16:59.371013 INFO: Running `flutter --no-version-check packages pub upgrade --no-example`...

## ✓ Follow Dart file conventions (30 / 30)
### [*] 10/10 points: Provide a valid `pubspec.yaml`

### [*] 5/5 points: Provide a valid `README.md`

### [*] 5/5 points: Provide a valid `CHANGELOG.md`

### [*] 10/10 points: Use an OSI-approved license

Detected license: `Apache-2.0`.


## ✓ Provide documentation (10 / 10)
### [*] 10/10 points: Package has an example


## ✓ Platform support (20 / 20)
### [*] 20/20 points: Supports 1 of 6 possible platforms (**iOS**, Android, Web, Windows, macOS, Linux)

* ✓ iOS


These platforms are not supported:

<details>
<summary>
Package does not support platform `Android`.
</summary>

Because:
* `package:flutter_inappwebview_ios/flutter_inappwebview_ios.dart` that declares support for platforms: `iOS`.
</details>

<details>
<summary>
Package does not support platform `Windows`.
</summary>

Because:
* `package:flutter_inappwebview_ios/flutter_inappwebview_ios.dart` that declares support for platforms: `iOS`.
</details>

<details>
<summary>
Package does not support platform `Linux`.
</summary>

Because:
* `package:flutter_inappwebview_ios/flutter_inappwebview_ios.dart` that declares support for platforms: `iOS`.
</details>

<details>
<summary>
Package does not support platform `macOS`.
</summary>

Because:
* `package:flutter_inappwebview_ios/flutter_inappwebview_ios.dart` that declares support for platforms: `iOS`.
</details>

<details>
<summary>
Package does not support platform `Web`.
</summary>

Because:
* `package:flutter_inappwebview_ios/flutter_inappwebview_ios.dart` that declares support for platforms: `iOS`.
</details>

### [x] 0/0 points: Swift Package Manager support

<details>
<summary>
Package does not support the Swift Package Manager on iOS
</summary>

It does not contain `ios/flutter_inappwebview_ios/Package.swift`.

</details>

This package for iOS or macOS does not support the Swift Package Manager. It will not receive full points in a future version of the scoring model.

See https://docs.flutter.dev/to/spm for details.


## ✗ Pass static analysis (40 / 50)
### [~] 40/50 points: code has no errors, warnings, lints, or formatting issues

Found 253 issues. Showing the first 2:

<details>
<summary>
INFO: Use 'const' with the constructor to improve performance.
</summary>

`lib/src/chrome_safari_browser/chrome_safari_browser.dart:24:12`

```
   ╷
24 │     return IOSChromeSafariBrowserCreationParams();
   │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
```

To reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `flutter analyze lib/src/chrome_safari_browser/chrome_safari_browser.dart`
</details>

<details>
<summary>
INFO: Use 'const' with the constructor to improve performance.
</summary>

`lib/src/chrome_safari_browser/chrome_safari_browser.dart:44:30`

```
   ╷
44 │       IOSChromeSafariBrowser(IOSChromeSafariBrowserCreationParams());
   │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
```

To reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `flutter analyze lib/src/chrome_safari_browser/chrome_safari_browser.dart`
</details>


## ✓ Support up-to-date dependencies (40 / 40)
### [*] 10/10 points: All of the package dependencies are supported in the latest version

|Package|Constraint|Compatible|Latest|Notes|
|:-|:-|:-|:-|:-|
|[`flutter_inappwebview_platform_interface`]|`../flutter_inappwebview_platform_interface`|1.4.0-beta.3|1.4.0-beta.3||

<details><summary>Transitive dependencies</summary>

|Package|Constraint|Compatible|Latest|Notes|
|:-|:-|:-|:-|:-|
|[`characters`]|-|1.4.0|1.4.1||
|[`collection`]|-|1.19.1|1.19.1||
|[`flutter_inappwebview_internal_annotations`]|-|1.3.0|1.3.0||
|[`material_color_utilities`]|-|0.11.1|0.13.0||
|[`meta`]|-|1.17.0|1.17.0||
|[`plugin_platform_interface`]|-|2.1.8|2.1.8||
|[`vector_math`]|-|2.2.0|2.2.0||
</details>

To reproduce run `dart pub outdated --no-dev-dependencies --up-to-date --no-dependency-overrides`.

[`flutter_inappwebview_platform_interface`]: https://pub.dev/packages/flutter_inappwebview_platform_interface
[`characters`]: https://pub.dev/packages/characters
[`collection`]: https://pub.dev/packages/collection
[`flutter_inappwebview_internal_annotations`]: https://pub.dev/packages/flutter_inappwebview_internal_annotations
[`material_color_utilities`]: https://pub.dev/packages/material_color_utilities
[`meta`]: https://pub.dev/packages/meta
[`plugin_platform_interface`]: https://pub.dev/packages/plugin_platform_interface
[`vector_math`]: https://pub.dev/packages/vector_math

### [*] 10/10 points: Package supports latest stable Dart and Flutter SDKs

### [*] 20/20 points: Compatible with dependency constraint lower bounds

`pub downgrade` does not expose any static analysis error.


Points: 140/150.
2025-12-30 16:17:00.219727 WARNING: Flutter SDK path was not specified, pana will use the default Dart SDK to run `dart analyze` on Flutter packages.
2025-12-30 16:17:00.225042 INFO: Running `dart --version`...
2025-12-30 16:17:00.269856 INFO: Running `flutter --no-version-check --version --machine`...
2025-12-30 16:17:00.557720 INFO: Running `git rev-parse --show-toplevel`...
2025-12-30 16:17:01.185084 INFO: Running `flutter --no-version-check pub pub get --no-example`...
2025-12-30 16:17:02.268310 INFO: Running `flutter --no-version-check pub pub get --no-example`...
2025-12-30 16:17:02.667155 INFO: Running `flutter --no-version-check pub pub outdated --json --up-to-date --no-dev-dependencies --no-dependency-overrides`...
2025-12-30 16:17:03.266637 INFO: Analyzing package...
2025-12-30 16:17:03.274596 INFO: Running `dart analyze --format machine lib`...
2025-12-30 16:17:07.494802 INFO: Running `git init`...
2025-12-30 16:17:07.505370 INFO: Running `git remote add origin https://github.com/pichillilorenzo/flutter_inappwebview`...
2025-12-30 16:17:07.512290 INFO: Running `git remote show origin`...
2025-12-30 16:17:08.012304 INFO: Running `git fetch --depth 1 --no-recurse-submodules origin master`...
2025-12-30 16:17:09.260824 INFO: Running `git ls-tree -r --name-only --full-tree origin/master`...
2025-12-30 16:17:09.272696 INFO: Running `git show origin/master:dev_packages/flutter_inappwebview_internal_annotations/pubspec.yaml`...
2025-12-30 16:17:09.280498 INFO: Running `git show origin/master:dev_packages/generators/pubspec.yaml`...
2025-12-30 16:17:09.287646 INFO: Running `git show origin/master:flutter_inappwebview/example/pubspec.yaml`...
2025-12-30 16:17:09.296160 INFO: Running `git show origin/master:flutter_inappwebview/pubspec.yaml`...
2025-12-30 16:17:09.304668 INFO: Running `git show origin/master:flutter_inappwebview_android/example/pubspec.yaml`...
2025-12-30 16:17:09.313158 INFO: Running `git show origin/master:flutter_inappwebview_android/pubspec.yaml`...
2025-12-30 16:17:09.320589 INFO: Running `git show origin/master:flutter_inappwebview_ios/example/pubspec.yaml`...
2025-12-30 16:17:09.328351 INFO: Running `git show origin/master:flutter_inappwebview_ios/pubspec.yaml`...
2025-12-30 16:17:09.335753 INFO: Running `git show origin/master:flutter_inappwebview_macos/example/pubspec.yaml`...
2025-12-30 16:17:09.343433 INFO: Running `git show origin/master:flutter_inappwebview_macos/pubspec.yaml`...
2025-12-30 16:17:09.351129 INFO: Running `git show origin/master:flutter_inappwebview_platform_interface/pubspec.yaml`...
2025-12-30 16:17:09.358532 INFO: Running `git show origin/master:flutter_inappwebview_web/example/pubspec.yaml`...
2025-12-30 16:17:09.365321 INFO: Running `git show origin/master:flutter_inappwebview_web/pubspec.yaml`...
2025-12-30 16:17:09.372223 INFO: Running `git show origin/master:flutter_inappwebview_windows/example/pubspec.yaml`...
2025-12-30 16:17:09.378655 INFO: Running `git show origin/master:flutter_inappwebview_windows/pubspec.yaml`...
2025-12-30 16:17:12.245497 INFO: Running `flutter --no-version-check packages pub get --no-example`...
2025-12-30 16:17:12.634445 INFO: Running `dart format --output=none --set-exit-if-changed /private/var/folders/x_/18wflq955xg_xq46dg740p5r0000gn/T/pana_BjpTIt/flutter_inappwebview_web/lib`...
2025-12-30 16:17:12.749052 INFO: Analyzing pub downgrade...
2025-12-30 16:17:12.750602 INFO: Running `flutter --no-version-check packages pub downgrade --no-example`...
2025-12-30 16:17:13.595572 INFO: Running `dart analyze --format machine lib`...
2025-12-30 16:17:14.716865 INFO: [pub-downgrade-success]
2025-12-30 16:17:14.718349 INFO: Running `flutter --no-version-check packages pub upgrade --no-example`...

## ✓ Follow Dart file conventions (30 / 30)
### [*] 10/10 points: Provide a valid `pubspec.yaml`

### [*] 5/5 points: Provide a valid `README.md`

### [*] 5/5 points: Provide a valid `CHANGELOG.md`

### [*] 10/10 points: Use an OSI-approved license

Detected license: `Apache-2.0`.


## ✓ Provide documentation (10 / 10)
### [*] 10/10 points: Package has an example


## ✓ Platform support (20 / 20)
### [*] 20/20 points: Supports 1 of 6 possible platforms (iOS, Android, **Web**, Windows, macOS, Linux)

* ✓ Web


These platforms are not supported:

<details>
<summary>
Package does not support platform `Android`.
</summary>

Because:
* `package:flutter_inappwebview_web/flutter_inappwebview_web.dart` that declares support for platforms: `Web`.
</details>

<details>
<summary>
Package does not support platform `iOS`.
</summary>

Because:
* `package:flutter_inappwebview_web/flutter_inappwebview_web.dart` that declares support for platforms: `Web`.
</details>

<details>
<summary>
Package does not support platform `Windows`.
</summary>

Because:
* `package:flutter_inappwebview_web/flutter_inappwebview_web.dart` that declares support for platforms: `Web`.
</details>

<details>
<summary>
Package does not support platform `Linux`.
</summary>

Because:
* `package:flutter_inappwebview_web/flutter_inappwebview_web.dart` that declares support for platforms: `Web`.
</details>

<details>
<summary>
Package does not support platform `macOS`.
</summary>

Because:
* `package:flutter_inappwebview_web/flutter_inappwebview_web.dart` that declares support for platforms: `Web`.
</details>


These issues are present but do not affect the score, because they may not originate in your package:

<details>
<summary>
Package not compatible with platform Web
</summary>

Because:
* `package:flutter_inappwebview_web/flutter_inappwebview_web.dart` that imports:
* `package:flutter_inappwebview_web/web/main.dart` that imports:
* `package:flutter_inappwebview_web/web/web_platform.dart` that imports:
* `package:flutter_inappwebview_web/web/platform_util.dart` that imports:
* `package:flutter_inappwebview_platform_interface/flutter_inappwebview_platform_interface.dart` that imports:
* `package:flutter_inappwebview_platform_interface/src/main.dart` that imports:
* `package:flutter_inappwebview_platform_interface/src/in_app_localhost_server.dart` that imports:
* `package:flutter_inappwebview_platform_interface/src/platform_in_app_localhost_server.dart` that imports:
* `dart:io`
</details>

### [x] 0/0 points: WASM compatibility

<details>
<summary>
Package not compatible with runtime wasm
</summary>

Because:
* `package:flutter_inappwebview_web/flutter_inappwebview_web.dart` that imports:
* `package:flutter_inappwebview_web/web/main.dart` that imports:
* `package:flutter_inappwebview_web/web/web_platform.dart` that imports:
* `package:flutter_inappwebview_web/web/platform_util.dart` that imports:
* `package:flutter_inappwebview_platform_interface/flutter_inappwebview_platform_interface.dart` that imports:
* `package:flutter_inappwebview_platform_interface/src/main.dart` that imports:
* `package:flutter_inappwebview_platform_interface/src/in_app_localhost_server.dart` that imports:
* `package:flutter_inappwebview_platform_interface/src/platform_in_app_localhost_server.dart` that imports:
* `dart:io`
</details>

This package is not compatible with runtime `wasm`, and will not be rewarded full points in a future version of the scoring model.

See https://dart.dev/web/wasm for details.


## ✗ Pass static analysis (30 / 50)
### [x] 30/50 points: code has no errors, warnings, lints, or formatting issues

Found 103 issues. Showing the first 2:

<details>
<summary>
WARNING: The declaration '_PlatformWebMessagePort.static' isn't referenced.
</summary>

`lib/src/inappwebview_platform.dart:459:35`

```
    ╷
459 │   factory _PlatformWebMessagePort.static() => _staticValue;
    │                                   ^^^^^^
    ╵
```

To reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `flutter analyze lib/src/inappwebview_platform.dart`
</details>

<details>
<summary>
INFO: Use 'const' with the constructor to improve performance.
</summary>

`lib/src/cookie_manager.dart:51:7`

```
   ╷
51 │ ┌       WebPlatformCookieManagerCreationParams(
52 │ │           PlatformCookieManagerCreationParams()));
   │ └────────────────────────────────────────────────^
   ╵
```

To reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `flutter analyze lib/src/cookie_manager.dart`
</details>


## ✓ Support up-to-date dependencies (40 / 40)
### [*] 10/10 points: All of the package dependencies are supported in the latest version

|Package|Constraint|Compatible|Latest|Notes|
|:-|:-|:-|:-|:-|
|[`flutter_inappwebview_platform_interface`]|`../flutter_inappwebview_platform_interface`|1.4.0-beta.3|1.4.0-beta.3||
|[`web`]|`^1.0.0`|1.1.1|1.1.1||

<details><summary>Transitive dependencies</summary>

|Package|Constraint|Compatible|Latest|Notes|
|:-|:-|:-|:-|:-|
|[`characters`]|-|1.4.0|1.4.1||
|[`collection`]|-|1.19.1|1.19.1||
|[`flutter_inappwebview_internal_annotations`]|-|1.3.0|1.3.0||
|[`material_color_utilities`]|-|0.11.1|0.13.0||
|[`meta`]|-|1.17.0|1.17.0||
|[`plugin_platform_interface`]|-|2.1.8|2.1.8||
|[`vector_math`]|-|2.2.0|2.2.0||
</details>

To reproduce run `dart pub outdated --no-dev-dependencies --up-to-date --no-dependency-overrides`.

[`flutter_inappwebview_platform_interface`]: https://pub.dev/packages/flutter_inappwebview_platform_interface
[`web`]: https://pub.dev/packages/web
[`characters`]: https://pub.dev/packages/characters
[`collection`]: https://pub.dev/packages/collection
[`flutter_inappwebview_internal_annotations`]: https://pub.dev/packages/flutter_inappwebview_internal_annotations
[`material_color_utilities`]: https://pub.dev/packages/material_color_utilities
[`meta`]: https://pub.dev/packages/meta
[`plugin_platform_interface`]: https://pub.dev/packages/plugin_platform_interface
[`vector_math`]: https://pub.dev/packages/vector_math

### [*] 10/10 points: Package supports latest stable Dart and Flutter SDKs

### [*] 20/20 points: Compatible with dependency constraint lower bounds

`pub downgrade` does not expose any static analysis error.


Points: 130/150.**
```


</details>


## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers

