### PR TITLE
macOS 11.x crash: WKWebViewConfiguration.upgradeKnownHostsToHTTPS unrecognized selector

### DIFF
--- a/flutter_inappwebview_macos/macos/Classes/InAppWebView/InAppWebView.swift
+++ b/flutter_inappwebview_macos/macos/Classes/InAppWebView/InAppWebView.swift
@@ -315,7 +315,12 @@ public class InAppWebView: WKWebView, WKUIDelegate,
             }
             
             if #available(macOS 11.3, *) {
-                configuration.upgradeKnownHostsToHTTPS = settings.upgradeKnownHostsToHTTPS
+                if configuration.responds(
+                    to: Selector(("setUpgradeKnownHostsToHTTPS:"))
+                ) {
+                    configuration.upgradeKnownHostsToHTTPS =
+                        settings.upgradeKnownHostsToHTTPS
+                }
             }
         }
         


### PR DESCRIPTION
### Summary

Fix crash on macOS 11.x caused by calling
`WKWebViewConfiguration.upgradeKnownHostsToHTTPS`
when the selector is not available at runtime.

### Details

Although `upgradeKnownHostsToHTTPS` is marked as
`API_AVAILABLE(macos(11.3))` in the SDK headers,
the corresponding Objective-C selector
`setUpgradeKnownHostsToHTTPS:` is missing from
WebKit at runtime on macOS 11.x (Big Sur).

Calling it results in:
-[WKWebViewConfiguration setUpgradeKnownHostsToHTTPS:]: unrecognized selector sent to instance

This PR guards the assignment with a runtime selector check,
preventing the crash while preserving behavior on macOS 12+.

### Affected platforms

- macOS 11.x (Big Sur)

Refs #2741

