### PR TITLE
Fix iPad crash in evaluateJavaScript when frame is nil

### DIFF
--- a/flutter_inappwebview_ios/ios/Classes/InAppWebView/InAppWebView.swift
+++ b/flutter_inappwebview_ios/ios/Classes/InAppWebView/InAppWebView.swift
@@ -1558,6 +1558,12 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         if let applePayAPIEnabled = settings?.applePayAPIEnabled, applePayAPIEnabled {
             return
         }
+        // PATCHED: frame nil check for iPad onCreateWindow crash
+        if frame == nil {
+            print("[InAppWebView Patch] Skipping evaluateJavaScript - frame is nil")
+            completionHandler?(.failure(NSError(domain: "InAppWebViewPatch", code: -1, userInfo: [NSLocalizedDescriptionKey: "Frame is nil"])))
+            return
+        }
         super.evaluateJavaScript(javaScript, in: frame, in: contentWorld, completionHandler: completionHandler)
     }
     


### PR DESCRIPTION
## Connection with issue(s)
Fixes a crash on iPad (iOS 14+) where `evaluateJavaScript` is called with a `nil` frame within `InAppWebView`.

## Testing and Review Notes
**What was fixed:**
Added a nil check for the `frame` parameter in `evaluateJavaScript`. Calling `super.evaluateJavaScript` with a `nil` frame was causing a crash on certain iPad configurations (e.g., during `onCreateWindow` or popup interactions).
**Steps to verify:**
1. Run the app on an iPad (iOS 14+).
2. Trigger a scenario involving window creation or popups where `evaluateJavaScript` might be invoked immediately (e.g., identity verification flows or auth popups).
3. Confirm that the app no longer crashes and handles the nil frame gracefully (returns an error via completion handler instead of crashing).

## Screenshots or Videos
N/A (Crash fix)

## To Do
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable)