### PR TITLE
Fix iOS 14~17 EXC_BAD_ACCESS crash when evaluateJavaScript on windowID WebViews

### DIFF
--- a/flutter_inappwebview_ios/ios/Classes/InAppWebView/InAppWebView.swift
+++ b/flutter_inappwebview_ios/ios/Classes/InAppWebView/InAppWebView.swift
@@ -1456,6 +1456,43 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         if let applePayAPIEnabled = settings?.applePayAPIEnabled, applePayAPIEnabled {
             return
         }
+        // MARK: - Workaround for iOS 14~17 EXC_BAD_ACCESS crash on windowId WebViews
+        //
+        // Problem:
+        //   On iOS 17 and below (iOS 14~17), calling evaluateJavaScript with contentWorld
+        //   parameter on WebViews created via windowId (popup windows from window.open or
+        //   target="_blank") causes EXC_BAD_ACCESS (code=1, address=0x0) - null pointer dereference.
+        //
+        // Root Cause Analysis (Based on code investigation, not official Apple documentation):
+        //   1. WindowId WebViews reuse the WKWebView instance created by the parent during
+        //      onCreateWindow (see FlutterWebViewController.swift:43-44).
+        //   2. These WebViews share the same WKWebViewConfiguration reference with the parent
+        //      (see InAppWebView.swift:502-506 - prepareAndAddUserScripts returns early).
+        //   3. WKContentWorld instances are associated with WKUserContentController, but
+        //      windowId WebViews skip custom UserContentController initialization.
+        //   4. When evaluateJavaScript is called with a custom contentWorld, the internal
+        //      content world state may not be properly initialized for the popup WebView.
+        //
+        // Affected iOS Versions:
+        //   - iOS 14.0~17.x: Crash occurs (iOS 14.0 introduced WKContentWorld API)
+        //   - iOS 18.0+: Apple may have fixed this issue (needs verification)
+        //   Note: This is based on testing and code analysis. Apple has not officially
+        //   documented these internal implementation details.
+        //
+        // Workaround:
+        //   Use the non-contentWorld version of evaluateJavaScript for windowId WebViews.
+        //   This uses WKContentWorld.page internally, which is always valid.
+        //
+        if #unavailable(iOS 18.0), windowId != nil {
+            super.evaluateJavaScript(javaScript) { result, error in
+                if let error = error {
+                    completionHandler?(.failure(error))
+                } else {
+                    completionHandler?(.success(result as Any))
+                }
+            }
+            return
+        }
         super.evaluateJavaScript(javaScript, in: frame, in: contentWorld, completionHandler: completionHandler)
     }
     
@@ -1471,6 +1508,15 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
     @available(iOS 14.0, *)
     public func callAsyncJavaScript(_ functionBody: String, arguments: [String : Any] = [:], frame: WKFrameInfo? = nil, contentWorld: WKContentWorld, completionHandler: ((Result<Any, Error>) -> Void)? = nil) {
         if let applePayAPIEnabled = settings?.applePayAPIEnabled, applePayAPIEnabled {
+            return
+        }
+        // MARK: - Workaround for iOS 14~17 EXC_BAD_ACCESS crash on windowId WebViews
+        // See evaluateJavaScript(_:frame:contentWorld:completionHandler:) above for detailed explanation.
+        // Same root cause: contentWorld parameter crashes on windowId WebViews (iOS 14~17)
+        // due to uninitialized WKContentWorld state in popup windows.
+        // Workaround: Use WKContentWorld.page which is always valid.
+        if #unavailable(iOS 18.0), windowId != nil {
+            super.callAsyncJavaScript(functionBody, arguments: arguments, in: frame, in: WKContentWorld.page, completionHandler: completionHandler)
             return
         }
         super.callAsyncJavaScript(functionBody, arguments: arguments, in: frame, in: contentWorld, completionHandler: completionHandler)


### PR DESCRIPTION

## Connection with issue(s)

Resolve issue #2600

## Testing and Review Notes

 ### Steps to reproduce the crash (before fix):                                                                                
                                                                                                                            
  1. Create a parent WebView with javaScriptCanOpenWindowsAutomatically: true and supportMultipleWindows: true              
  2. Trigger window.open() or click a link with target="_blank" to open a popup window                                      
  3. Create a child WebView with the windowId from onCreateWindow                                                           
  4. Call evaluateJavascript() on the child WebView                                                                         
  5. Result: App crashes with EXC_BAD_ACCESS (code=1, address=0x0) on iOS 14~17                                             
                                                                                                                            
###  Steps to verify the fix:                                                                                                  
                                                                                                                            
  1. Repeat the same steps above                                                                                            
  2. Expected Result: evaluateJavascript() works without crash on iOS 14~17                                                 
  3. Note: iOS 18+ uses the original behavior with contentWorld parameter                                                   
                                                                                                                            
###  Root Cause:                                                                                                               
                                                                                                                            
  - WindowId WebViews reuse WKWebView from parent and share WKWebViewConfiguration                                          
  - They skip custom WKUserContentController initialization                                                                 
  - When evaluateJavaScript is called with contentWorld parameter, the internal content world state is not properly         
  initialized for popup WebViews                                                    

                                                                                                                            
###  Workaround Applied:                                                                                                       
                                                                                                                            
  - On iOS < 18: Use non-contentWorld version of evaluateJavaScript for windowId WebViews                                   
  - On iOS 18+: Use original behavior (Apple may have fixed this issue)   

## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] request the "UX" team perform a design review (if/when applicable)
