### PR TITLE
windows: emit minimize/restore events to keep custom platform view synced

### DIFF
--- a/flutter_inappwebview_windows/lib/src/in_app_webview/custom_platform_view.dart
+++ b/flutter_inappwebview_windows/lib/src/in_app_webview/custom_platform_view.dart
@@ -357,6 +357,18 @@ class _CustomPlatformViewState extends State<CustomPlatformView>
   }
 
   @override
+  void onWindowMinimize() {
+    _reportSurfaceSize();
+    _reportWidgetPosition();
+  }
+
+  @override
+  void onWindowRestore() {
+    _reportSurfaceSize();
+    _reportWidgetPosition();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Focus(
       autofocus: true,

--- a/flutter_inappwebview_windows/lib/src/platform_util.dart
+++ b/flutter_inappwebview_windows/lib/src/platform_util.dart
@@ -5,6 +5,8 @@ abstract mixin class PlatformUtilListener {
   void onWindowMove() {}
   void onWindowStartMove() {}
   void onWindowEndMove() {}
+  void onWindowMinimize() {}
+  void onWindowRestore() {}
 }
 
 ///Platform native utilities
@@ -50,6 +52,12 @@ class PlatformUtil {
             break;
           case 'onWindowEndMove':
             listener.onWindowEndMove();
+            break;
+          case 'onWindowMinimize':
+            listener.onWindowMinimize();
+            break;
+          case 'onWindowRestore':
+            listener.onWindowRestore();
             break;
         }
       }

--- a/flutter_inappwebview_windows/windows/platform_util.cpp
+++ b/flutter_inappwebview_windows/windows/platform_util.cpp
@@ -57,6 +57,22 @@ namespace flutter_inappwebview_plugin
         _EmitEvent("onWindowEndMove");
       }
     }
+    else if (message == WM_SIZE) {
+      if (wParam == SIZE_MINIMIZED) {
+        if (!window_is_minimized_) {
+          window_is_minimized_ = true;
+          _EmitEvent("onWindowMinimize");
+        }
+        _EmitEvent("onWindowMove");
+      }
+      else if (wParam == SIZE_RESTORED || wParam == SIZE_MAXIMIZED) {
+        if (window_is_minimized_) {
+          window_is_minimized_ = false;
+          _EmitEvent("onWindowRestore");
+        }
+        _EmitEvent("onWindowMove");
+      }
+    }
 
     return result;
   }

--- a/flutter_inappwebview_windows/windows/platform_util.h
+++ b/flutter_inappwebview_windows/windows/platform_util.h
@@ -35,6 +35,7 @@ namespace flutter_inappwebview_plugin
     void PlatformUtil::_EmitEvent(std::string eventName);
     bool window_is_moving_ = false;
     bool window_start_move_sent_ = false;
+    bool window_is_minimized_ = false;
   };
 }
 


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #2789 

Connected to #2789 

## Testing and Review Notes

### Background
Issue #2789  describes a Windows-specific case where, after minimizing/moving a Flutter app using `InAppWebView`, desktop interaction can be blocked by an overlay-like stale platform view state.

### Root Cause
In `flutter_inappwebview_windows`, platform view geometry sync was primarily driven by move-related events (`WM_MOVING`, `WM_EXITSIZEMOVE`) and app lifecycle callbacks.  
Minimize/restore transitions (`WM_SIZE` with `SIZE_MINIMIZED` / `SIZE_RESTORED` / `SIZE_MAXIMIZED`) were not explicitly emitted through `PlatformUtil`, so `CustomPlatformView` could miss position/size resync on those transitions.

### What this PR changes
- Add minimize/restore event support in `PlatformUtilListener` (Dart):
  - `onWindowMinimize`
  - `onWindowRestore`
- Emit those events from native Windows layer:
  - `WM_SIZE + SIZE_MINIMIZED` -> `onWindowMinimize` (and `onWindowMove`)
  - `WM_SIZE + SIZE_RESTORED/SIZE_MAXIMIZED` -> `onWindowRestore` (and `onWindowMove`)
- Handle the new events in `CustomPlatformView` by forcing:
  - `_reportSurfaceSize()`
  - `_reportWidgetPosition()`

### Files changed
- `flutter_inappwebview_windows/windows/platform_util.cpp`
- `flutter_inappwebview_windows/windows/platform_util.h`
- `flutter_inappwebview_windows/lib/src/platform_util.dart`
- `flutter_inappwebview_windows/lib/src/in_app_webview/custom_platform_view.dart`

### Manual test steps
1. Run the Windows example/app that hosts `InAppWebView`.
2. Load any regular page (e.g., `https://google.com`).
3. Minimize the app window.
4. Verify desktop icons remain clickable and no overlay-like blocked region remains.
5. Restore/maximize the app window.
6. Verify WebView remains visible and interactive.
7. Move the window around and verify WebView tracks position correctly.

### Regression checks
- Existing move event behavior still works (`onWindowMove`, `onWindowStartMove`, `onWindowEndMove`).
- No API breaking changes (only additive listener methods).
- Windows build succeeds with the new native branch.

## Screenshots or Videos

- Before fix:
https://github.com/user-attachments/assets/e4fdcc32-d8c5-46d0-899a-1a133533748f

- After fix: 
https://github.com/user-attachments/assets/eb141537-cdbe-4eb1-901b-6f9b794881d6


