### PR TITLE
Add ProxyController support for Windows (WebView2)

### DIFF
--- a/flutter_inappwebview/lib/src/in_app_webview/in_app_webview_controller.dart
+++ b/flutter_inappwebview/lib/src/in_app_webview/in_app_webview_controller.dart
@@ -648,6 +648,18 @@ class InAppWebViewController {
   ///{@macro flutter_inappwebview_platform_interface.PlatformInAppWebViewController.resume.supported_platforms}
   Future<void> resume() => platform.resume();
 
+  ///{@macro flutter_inappwebview_platform_interface.PlatformInAppWebViewController.setVirtualHostNameToFolderMapping}
+  Future<bool> setVirtualHostNameToFolderMapping({
+    required String hostName,
+    required String folderPath,
+    VirtualHostResourceAccessKind accessKind =
+        VirtualHostResourceAccessKind.DENY,
+  }) => platform.setVirtualHostNameToFolderMapping(
+    hostName: hostName,
+    folderPath: folderPath,
+    accessKind: accessKind,
+  );
+
   ///{@macro flutter_inappwebview_platform_interface.PlatformInAppWebViewController.pageDown}
   ///
   ///{@macro flutter_inappwebview_platform_interface.PlatformInAppWebViewController.pageDown.supported_platforms}

--- a/flutter_inappwebview/pubspec.yaml
+++ b/flutter_inappwebview/pubspec.yaml
@@ -20,20 +20,20 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_inappwebview_platform_interface: ^1.4.0-beta.3
-    # path: ../flutter_inappwebview_platform_interface
-  flutter_inappwebview_android: ^1.2.0-beta.3
-    # path: ../flutter_inappwebview_android
-  flutter_inappwebview_ios: ^1.2.0-beta.3
-    # path: ../flutter_inappwebview_ios
-  flutter_inappwebview_macos: ^1.2.0-beta.3
-    # path: ../flutter_inappwebview_macos
-  flutter_inappwebview_web: ^1.2.0-beta.3
-    # path: ../flutter_inappwebview_web
-  flutter_inappwebview_windows: ^0.7.0-beta.3
-    # path: ../flutter_inappwebview_windows
-  flutter_inappwebview_linux: ^0.1.0-beta.1
-    # path: ../flutter_inappwebview_linux
+  flutter_inappwebview_platform_interface:
+    path: ../flutter_inappwebview_platform_interface
+  flutter_inappwebview_android:
+    path: ../flutter_inappwebview_android
+  flutter_inappwebview_ios:
+    path: ../flutter_inappwebview_ios
+  flutter_inappwebview_macos:
+    path: ../flutter_inappwebview_macos
+  flutter_inappwebview_web:
+    path: ../flutter_inappwebview_web
+  flutter_inappwebview_windows:
+    path: ../flutter_inappwebview_windows
+  flutter_inappwebview_linux:
+    path: ../flutter_inappwebview_linux
 
 dev_dependencies:
   flutter_test:

--- a/flutter_inappwebview_android/pubspec.yaml
+++ b/flutter_inappwebview_android/pubspec.yaml
@@ -20,8 +20,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_inappwebview_platform_interface: ^1.4.0-beta.3
-    # path: ../flutter_inappwebview_platform_interface
+  flutter_inappwebview_platform_interface:
+    path: ../flutter_inappwebview_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/flutter_inappwebview_ios/pubspec.yaml
+++ b/flutter_inappwebview_ios/pubspec.yaml
@@ -20,8 +20,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_inappwebview_platform_interface: ^1.4.0-beta.3
-    # path: ../flutter_inappwebview_platform_interface
+  flutter_inappwebview_platform_interface:
+    path: ../flutter_inappwebview_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/flutter_inappwebview_linux/pubspec.yaml
+++ b/flutter_inappwebview_linux/pubspec.yaml
@@ -20,8 +20,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_inappwebview_platform_interface: ^1.4.0-beta.3
-    # path: ../flutter_inappwebview_platform_interface
+  flutter_inappwebview_platform_interface:
+    path: ../flutter_inappwebview_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/flutter_inappwebview_macos/pubspec.yaml
+++ b/flutter_inappwebview_macos/pubspec.yaml
@@ -20,8 +20,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_inappwebview_platform_interface: ^1.4.0-beta.3
-    # path: ../flutter_inappwebview_platform_interface
+  flutter_inappwebview_platform_interface:
+    path: ../flutter_inappwebview_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/flutter_inappwebview_platform_interface/lib/src/in_app_webview/platform_inappwebview_controller.dart
+++ b/flutter_inappwebview_platform_interface/lib/src/in_app_webview/platform_inappwebview_controller.dart
@@ -3028,6 +3028,31 @@ abstract class PlatformInAppWebViewController extends PlatformInterface
     );
   }
 
+  ///{@template flutter_inappwebview_platform_interface.PlatformInAppWebViewController.setVirtualHostNameToFolderMapping}
+  ///Maps [hostName] to the local [folderPath] so the WebView serves requests
+  ///to `https://<hostName>/...` from that folder without hitting the network.
+  ///The document loaded from a mapped host gets a regular `https` origin of
+  ///that host name.
+  ///
+  ///Call it before navigating to the mapped host. [accessKind] controls
+  ///cross-origin access to the mapped resources.
+  ///
+  ///Returns `true` when the mapping has been applied.
+  ///
+  ///Officially Supported Platforms/Implementations:
+  ///- Windows ([ICoreWebView2_3.SetVirtualHostNameToFolderMapping](https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/icorewebview2_3#setvirtualhostnametofoldermapping))
+  ///{@endtemplate}
+  Future<bool> setVirtualHostNameToFolderMapping({
+    required String hostName,
+    required String folderPath,
+    VirtualHostResourceAccessKind accessKind =
+        VirtualHostResourceAccessKind.DENY,
+  }) {
+    throw UnimplementedError(
+      'setVirtualHostNameToFolderMapping is not implemented on the current platform',
+    );
+  }
+
   ///{@template flutter_inappwebview_platform_interface.PlatformInAppWebViewController.pageDown}
   ///Scrolls the contents of this WebView down by half the page size.
   ///Returns `true` if the page was scrolled.
@@ -4742,4 +4767,25 @@ abstract class PlatformInAppWebViewController extends PlatformInterface
       '${PlatformInAppWebViewControllerMethod.dispose.name} is not implemented on the current platform',
     );
   }
+}
+
+///Cross-origin access policy for resources served through
+///[PlatformInAppWebViewController.setVirtualHostNameToFolderMapping].
+///
+///Values mirror the WebView2 `COREWEBVIEW2_HOST_RESOURCE_ACCESS_KIND` enum.
+enum VirtualHostResourceAccessKind {
+  ///All cross-origin access to the mapped resources is denied.
+  DENY(0),
+
+  ///All cross-origin access is allowed, including access from origins that
+  ///could not normally read local resources.
+  ALLOW(1),
+
+  ///Cross-origin access follows regular CORS rules.
+  DENY_CORS(2);
+
+  final int nativeValue;
+  const VirtualHostResourceAccessKind(this.nativeValue);
+
+  int toNativeValue() => nativeValue;
 }

--- a/flutter_inappwebview_platform_interface/lib/src/in_app_webview/platform_inappwebview_controller.dart
+++ b/flutter_inappwebview_platform_interface/lib/src/in_app_webview/platform_inappwebview_controller.dart
@@ -4768,24 +4768,3 @@ abstract class PlatformInAppWebViewController extends PlatformInterface
     );
   }
 }
-
-///Cross-origin access policy for resources served through
-///[PlatformInAppWebViewController.setVirtualHostNameToFolderMapping].
-///
-///Values mirror the WebView2 `COREWEBVIEW2_HOST_RESOURCE_ACCESS_KIND` enum.
-enum VirtualHostResourceAccessKind {
-  ///All cross-origin access to the mapped resources is denied.
-  DENY(0),
-
-  ///All cross-origin access is allowed, including access from origins that
-  ///could not normally read local resources.
-  ALLOW(1),
-
-  ///Cross-origin access follows regular CORS rules.
-  DENY_CORS(2);
-
-  final int nativeValue;
-  const VirtualHostResourceAccessKind(this.nativeValue);
-
-  int toNativeValue() => nativeValue;
-}

--- a/flutter_inappwebview_platform_interface/lib/src/platform_proxy_controller.dart
+++ b/flutter_inappwebview_platform_interface/lib/src/platform_proxy_controller.dart
@@ -25,6 +25,7 @@ part 'platform_proxy_controller.g.dart';
     IOSPlatform(),
     MacOSPlatform(),
     LinuxPlatform(),
+    WindowsPlatform(),
   ],
 )
 @immutable
@@ -75,6 +76,14 @@ class PlatformProxyControllerCreationParams {
       apiName: 'WebKitNetworkProxySettings',
       apiUrl:
           'https://wpewebkit.org/reference/stable/wpe-webkit-2.0/struct.NetworkProxySettings.html',
+    ),
+    WindowsPlatform(
+      apiName: 'WebView2 --proxy-server',
+      apiUrl:
+          'https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions',
+      note:
+          'Proxy is set via --proxy-server browser argument when creating WebView2 environment. '
+          'Must be set before WebView creation; runtime changes require recreating the environment.',
     ),
   ],
 )
@@ -158,6 +167,13 @@ abstract class PlatformProxyController extends PlatformInterface {
         apiUrl:
             'https://wpewebkit.org/reference/stable/wpe-webkit-2.0/method.NetworkSession.set_proxy_settings.html',
       ),
+      WindowsPlatform(
+        apiName: 'WebView2 --proxy-server',
+        apiUrl:
+            'https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions',
+        note:
+            'Stores proxy settings for subsequent WebView2 environment creation via --proxy-server argument.',
+      ),
     ],
   )
   Future<void> setProxyOverride({required ProxySettings settings}) {
@@ -196,6 +212,12 @@ abstract class PlatformProxyController extends PlatformInterface {
         apiName: 'webkit_network_session_set_proxy_settings',
         apiUrl:
             'https://wpewebkit.org/reference/stable/wpe-webkit-2.0/method.NetworkSession.set_proxy_settings.html',
+      ),
+      WindowsPlatform(
+        apiName: 'WebView2 --proxy-server',
+        apiUrl:
+            'https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions',
+        note: 'Clears stored proxy settings.',
       ),
     ],
   )
@@ -250,6 +272,7 @@ abstract class PlatformProxyController extends PlatformInterface {
       apiUrl:
           'https://wpewebkit.org/reference/stable/wpe-webkit-2.0/struct.NetworkProxySettings.html',
     ),
+    WindowsPlatform(),
   ],
 )
 @ExchangeableObject(copyMethod: true)
@@ -268,6 +291,10 @@ class ProxySettings_ {
             'https://wpewebkit.org/reference/stable/wpe-webkit-2.0/ctor.NetworkProxySettings.new.html',
         note:
             'Mapped to ignore_hosts; bypass rules are passed as host patterns to WebKitNetworkProxySettings.',
+      ),
+      WindowsPlatform(
+        note:
+            'Mapped to --proxy-bypass-list browser argument.',
       ),
     ],
   )
@@ -293,6 +320,7 @@ class ProxySettings_ {
       IOSPlatform(),
       MacOSPlatform(),
       LinuxPlatform(),
+      WindowsPlatform(),
     ],
   )
   List<ProxyRule_> proxyRules;

--- a/flutter_inappwebview_platform_interface/lib/src/platform_proxy_controller.g.dart
+++ b/flutter_inappwebview_platform_interface/lib/src/platform_proxy_controller.g.dart
@@ -211,6 +211,7 @@ extension _PlatformProxyControllerCreationParamsClassSupported
           TargetPlatform.iOS,
           TargetPlatform.macOS,
           TargetPlatform.linux,
+          TargetPlatform.windows,
         ].contains(platform ?? defaultTargetPlatform);
   }
 }
@@ -233,6 +234,7 @@ extension _PlatformProxyControllerClassSupported on PlatformProxyController {
           TargetPlatform.iOS,
           TargetPlatform.macOS,
           TargetPlatform.linux,
+          TargetPlatform.windows,
         ].contains(platform ?? defaultTargetPlatform);
   }
 }
@@ -315,6 +317,7 @@ extension _ProxySettingsClassSupported on ProxySettings {
           TargetPlatform.iOS,
           TargetPlatform.macOS,
           TargetPlatform.linux,
+          TargetPlatform.windows,
         ].contains(platform ?? defaultTargetPlatform);
   }
 }
@@ -404,6 +407,7 @@ extension _ProxySettingsPropertySupported on ProxySettings {
             [
               TargetPlatform.android,
               TargetPlatform.linux,
+              TargetPlatform.windows,
             ].contains(platform ?? defaultTargetPlatform);
       case ProxySettingsProperty.bypassSimpleHostnames:
         return ((kIsWeb && platform != null) || !kIsWeb) &&

--- a/flutter_inappwebview_platform_interface/lib/src/types/main.dart
+++ b/flutter_inappwebview_platform_interface/lib/src/types/main.dart
@@ -286,3 +286,5 @@ export 'show_file_chooser_response.dart' show ShowFileChooserResponse;
 export 'cache_model.dart' show CacheModel;
 export 'font_hinting_style.dart' show FontHintingStyle;
 export 'font_subpixel_layout.dart' show FontSubpixelLayout;
+export 'virtual_host_resource_access_kind.dart'
+    show VirtualHostResourceAccessKind;

--- a/flutter_inappwebview_platform_interface/lib/src/types/virtual_host_resource_access_kind.dart
+++ b/flutter_inappwebview_platform_interface/lib/src/types/virtual_host_resource_access_kind.dart
@@ -1,0 +1,22 @@
+import '../in_app_webview/platform_inappwebview_controller.dart';
+
+///Cross-origin access policy for resources served through
+///[PlatformInAppWebViewController.setVirtualHostNameToFolderMapping].
+///
+///Values mirror the WebView2 `COREWEBVIEW2_HOST_RESOURCE_ACCESS_KIND` enum.
+enum VirtualHostResourceAccessKind {
+  ///All cross-origin access to the mapped resources is denied.
+  DENY(0),
+
+  ///All cross-origin access is allowed, including access from origins that
+  ///could not normally read local resources.
+  ALLOW(1),
+
+  ///Cross-origin access follows regular CORS rules.
+  DENY_CORS(2);
+
+  final int nativeValue;
+  const VirtualHostResourceAccessKind(this.nativeValue);
+
+  int toNativeValue() => nativeValue;
+}

--- a/flutter_inappwebview_web/pubspec.yaml
+++ b/flutter_inappwebview_web/pubspec.yaml
@@ -23,8 +23,8 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   web: ^1.0.0
-  flutter_inappwebview_platform_interface: ^1.4.0-beta.3
-    # path: ../flutter_inappwebview_platform_interface
+  flutter_inappwebview_platform_interface:
+    path: ../flutter_inappwebview_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/flutter_inappwebview_windows/lib/src/in_app_webview/in_app_webview_controller.dart
+++ b/flutter_inappwebview_windows/lib/src/in_app_webview/in_app_webview_controller.dart
@@ -3402,6 +3402,24 @@ class WindowsInAppWebViewController extends PlatformInAppWebViewController
   }
 
   @override
+  Future<bool> setVirtualHostNameToFolderMapping({
+    required String hostName,
+    required String folderPath,
+    VirtualHostResourceAccessKind accessKind =
+        VirtualHostResourceAccessKind.DENY,
+  }) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('hostName', () => hostName);
+    args.putIfAbsent('folderPath', () => folderPath);
+    args.putIfAbsent('accessKind', () => accessKind.toNativeValue());
+    return await channel?.invokeMethod<bool>(
+          'setVirtualHostNameToFolderMapping',
+          args,
+        ) ??
+        false;
+  }
+
+  @override
   Future<bool> isInterfaceSupported(WebViewInterface interface) async {
     Map<String, dynamic> args = <String, dynamic>{};
     args.putIfAbsent('interface', () => interface.toNativeValue());

--- a/flutter_inappwebview_windows/lib/src/inappwebview_platform.dart
+++ b/flutter_inappwebview_windows/lib/src/inappwebview_platform.dart
@@ -6,6 +6,7 @@ import 'in_app_browser/in_app_browser.dart';
 import 'in_app_webview/headless_in_app_webview.dart';
 import 'in_app_webview/in_app_webview.dart';
 import 'in_app_webview/in_app_webview_controller.dart';
+import 'proxy_controller.dart';
 import 'web_message/web_message_channel.dart';
 import 'web_message/web_message_listener.dart';
 import 'web_message/web_message_port.dart';
@@ -352,13 +353,24 @@ class WindowsInAppWebViewPlatform extends InAppWebViewPlatform {
     return _PlatformProcessGlobalConfig.static();
   }
 
-  /// Creates a new empty [PlatformProxyController] to access static methods.
+  /// Creates a new [WindowsProxyController].
   ///
   /// This function should only be called by the app-facing package.
   /// Look at using [ProxyController] in `flutter_inappwebview` instead.
   @override
-  PlatformProxyController createPlatformProxyControllerStatic() {
-    return _PlatformProxyController.static();
+  WindowsProxyController createPlatformProxyController(
+    PlatformProxyControllerCreationParams params,
+  ) {
+    return WindowsProxyController(params);
+  }
+
+  /// Creates a new empty [WindowsProxyController] to access static methods.
+  ///
+  /// This function should only be called by the app-facing package.
+  /// Look at using [ProxyController] in `flutter_inappwebview` instead.
+  @override
+  WindowsProxyController createPlatformProxyControllerStatic() {
+    return WindowsProxyController.static();
   }
 
   /// Creates a new empty [PlatformServiceWorkerController] to access static methods.
@@ -511,15 +523,6 @@ class _PlatformProcessGlobalConfig extends PlatformProcessGlobalConfig {
   factory _PlatformProcessGlobalConfig.static() => _staticValue;
 }
 
-class _PlatformProxyController extends PlatformProxyController {
-  _PlatformProxyController(PlatformProxyControllerCreationParams params)
-    : super.implementation(params);
-  static final _PlatformProxyController _staticValue = _PlatformProxyController(
-    const PlatformProxyControllerCreationParams(),
-  );
-
-  factory _PlatformProxyController.static() => _staticValue;
-}
 
 class _PlatformServiceWorkerController extends PlatformServiceWorkerController {
   _PlatformServiceWorkerController(

--- a/flutter_inappwebview_windows/lib/src/main.dart
+++ b/flutter_inappwebview_windows/lib/src/main.dart
@@ -3,6 +3,7 @@ export 'in_app_webview/main.dart';
 export 'in_app_browser/main.dart';
 export 'web_storage/main.dart';
 export 'cookie_manager.dart' hide InternalCookieManager;
+export 'proxy_controller.dart' hide InternalProxyController;
 export 'http_auth_credentials_database.dart'
     hide InternalHttpAuthCredentialDatabase;
 export 'print_job/main.dart';

--- a/flutter_inappwebview_windows/lib/src/proxy_controller.dart
+++ b/flutter_inappwebview_windows/lib/src/proxy_controller.dart
@@ -1,0 +1,99 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_inappwebview_platform_interface/flutter_inappwebview_platform_interface.dart';
+
+/// Object specifying creation parameters for creating a [WindowsProxyController].
+///
+/// When adding additional fields make sure they can be null or have a default
+/// value to avoid breaking changes. See [PlatformProxyControllerCreationParams] for
+/// more information.
+@immutable
+class WindowsProxyControllerCreationParams
+    extends PlatformProxyControllerCreationParams {
+  /// Creates a new [WindowsProxyControllerCreationParams] instance.
+  const WindowsProxyControllerCreationParams(
+    // This parameter prevents breaking changes later.
+    // ignore: avoid_unused_constructor_parameters
+    PlatformProxyControllerCreationParams params,
+  ) : super();
+
+  /// Creates a [WindowsProxyControllerCreationParams] instance based on [PlatformProxyControllerCreationParams].
+  factory WindowsProxyControllerCreationParams.fromPlatformProxyControllerCreationParams(
+    PlatformProxyControllerCreationParams params,
+  ) {
+    return WindowsProxyControllerCreationParams(params);
+  }
+}
+
+///{@macro flutter_inappwebview_platform_interface.PlatformProxyController}
+class WindowsProxyController extends PlatformProxyController
+    with ChannelController {
+  /// Creates a new [WindowsProxyController].
+  WindowsProxyController(PlatformProxyControllerCreationParams params)
+    : super.implementation(
+        params is WindowsProxyControllerCreationParams
+            ? params
+            : WindowsProxyControllerCreationParams.fromPlatformProxyControllerCreationParams(
+                params,
+              ),
+      ) {
+    channel = const MethodChannel(
+      'com.pichillilorenzo/flutter_inappwebview_proxycontroller',
+    );
+    handler = handleMethod;
+    initMethodCallHandler();
+  }
+
+  static WindowsProxyController? _instance;
+
+  ///Gets the [WindowsProxyController] shared instance.
+  static WindowsProxyController instance() {
+    return (_instance != null) ? _instance! : _init();
+  }
+
+  static WindowsProxyController _init() {
+    _instance = WindowsProxyController(
+      WindowsProxyControllerCreationParams(
+        const PlatformProxyControllerCreationParams(),
+      ),
+    );
+    return _instance!;
+  }
+
+  static final WindowsProxyController _staticValue = WindowsProxyController(
+    WindowsProxyControllerCreationParams(
+      const PlatformProxyControllerCreationParams(),
+    ),
+  );
+
+  /// Provide static access.
+  factory WindowsProxyController.static() {
+    return _staticValue;
+  }
+
+  Future<dynamic> _handleMethod(MethodCall call) async {}
+
+  @override
+  Future<void> setProxyOverride({required ProxySettings settings}) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent("settings", () => settings.toMap());
+    await channel?.invokeMethod('setProxyOverride', args);
+  }
+
+  @override
+  Future<void> clearProxyOverride() async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    await channel?.invokeMethod('clearProxyOverride', args);
+  }
+
+  @override
+  void dispose() {
+    // empty
+  }
+}
+
+extension InternalProxyController on WindowsProxyController {
+  get handleMethod => _handleMethod;
+}

--- a/flutter_inappwebview_windows/pubspec.yaml
+++ b/flutter_inappwebview_windows/pubspec.yaml
@@ -20,8 +20,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_inappwebview_platform_interface: ^1.4.0-beta.3
-    # path: ../flutter_inappwebview_platform_interface
+  flutter_inappwebview_platform_interface:
+    path: ../flutter_inappwebview_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/flutter_inappwebview_windows/test/proxy_controller_test.dart
+++ b/flutter_inappwebview_windows/test/proxy_controller_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_inappwebview_platform_interface/flutter_inappwebview_platform_interface.dart';
+import 'package:flutter_inappwebview_windows/src/proxy_controller.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late WindowsProxyController controller;
+  late List<MethodCall> log;
+
+  setUp(() {
+    log = [];
+    controller = WindowsProxyController.static();
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel(
+          'com.pichillilorenzo/flutter_inappwebview_proxycontroller'),
+      (call) async {
+        log.add(call);
+        return true;
+      },
+    );
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel(
+          'com.pichillilorenzo/flutter_inappwebview_proxycontroller'),
+      null,
+    );
+  });
+
+  group('WindowsProxyController', () {
+    test('setProxyOverride sends correct method call', () async {
+      await controller.setProxyOverride(
+        settings: ProxySettings(
+          proxyRules: [ProxyRule(url: 'http://proxy.example.com:8080')],
+        ),
+      );
+
+      expect(log, hasLength(1));
+      expect(log.first.method, 'setProxyOverride');
+
+      final args = log.first.arguments as Map<dynamic, dynamic>;
+      expect(args.containsKey('settings'), isTrue);
+
+      final settings = args['settings'] as Map<dynamic, dynamic>;
+      final rules = settings['proxyRules'] as List;
+      expect(rules, hasLength(1));
+      expect((rules.first as Map)['url'], 'http://proxy.example.com:8080');
+    });
+
+    test('setProxyOverride with bypass rules', () async {
+      await controller.setProxyOverride(
+        settings: ProxySettings(
+          proxyRules: [ProxyRule(url: 'http://proxy:8080')],
+          bypassRules: ['localhost', '*.example.com'],
+        ),
+      );
+
+      expect(log, hasLength(1));
+      final args = log.first.arguments as Map<dynamic, dynamic>;
+      final settings = args['settings'] as Map<dynamic, dynamic>;
+      expect(settings['bypassRules'], ['localhost', '*.example.com']);
+    });
+
+    test('clearProxyOverride sends correct method call', () async {
+      await controller.clearProxyOverride();
+
+      expect(log, hasLength(1));
+      expect(log.first.method, 'clearProxyOverride');
+    });
+
+    test('setProxyOverride with multiple proxy rules', () async {
+      await controller.setProxyOverride(
+        settings: ProxySettings(
+          proxyRules: [
+            ProxyRule(
+              url: 'http://http-proxy:80',
+              schemeFilter: ProxySchemeFilter.MATCH_HTTP,
+            ),
+            ProxyRule(
+              url: 'https://https-proxy:443',
+              schemeFilter: ProxySchemeFilter.MATCH_HTTPS,
+            ),
+          ],
+        ),
+      );
+
+      expect(log, hasLength(1));
+      final args = log.first.arguments as Map<dynamic, dynamic>;
+      final settings = args['settings'] as Map<dynamic, dynamic>;
+      final rules = settings['proxyRules'] as List;
+      expect(rules, hasLength(2));
+    });
+  });
+
+  group('ProxySettings toMap/fromMap', () {
+    test('roundtrip with proxy rules', () {
+      final settings = ProxySettings(
+        proxyRules: [
+          ProxyRule(url: 'http://proxy:8080'),
+          ProxyRule(
+              url: 'socks5://socks:1080',
+              schemeFilter: ProxySchemeFilter.MATCH_ALL_SCHEMES),
+        ],
+        bypassRules: ['localhost', '10.0.0.0/8'],
+      );
+
+      final map = settings.toMap();
+      final restored = ProxySettings.fromMap(map);
+
+      expect(restored, isNotNull);
+      expect(restored!.proxyRules, hasLength(2));
+      expect(restored.proxyRules[0].url, 'http://proxy:8080');
+      expect(restored.proxyRules[1].url, 'socks5://socks:1080');
+      expect(restored.bypassRules, ['localhost', '10.0.0.0/8']);
+    });
+
+    test('fromMap with null returns null', () {
+      expect(ProxySettings.fromMap(null), isNull);
+    });
+
+    test('empty settings roundtrip', () {
+      final settings = ProxySettings();
+      final map = settings.toMap();
+      final restored = ProxySettings.fromMap(map);
+
+      expect(restored, isNotNull);
+      expect(restored!.proxyRules, isEmpty);
+      expect(restored.bypassRules, isEmpty);
+    });
+  });
+
+  group('isClassSupported', () {
+    test('Windows is supported', () {
+      expect(
+        ProxySettings.isClassSupported(platform: TargetPlatform.windows),
+        isTrue,
+      );
+    });
+
+    test('all platforms are supported', () {
+      for (final platform in [
+        TargetPlatform.android,
+        TargetPlatform.iOS,
+        TargetPlatform.macOS,
+        TargetPlatform.linux,
+        TargetPlatform.windows,
+      ]) {
+        expect(
+          ProxySettings.isClassSupported(platform: platform),
+          isTrue,
+          reason: '$platform should be supported',
+        );
+      }
+    });
+  });
+}

--- a/flutter_inappwebview_windows/windows/CMakeLists.txt
+++ b/flutter_inappwebview_windows/windows/CMakeLists.txt
@@ -247,6 +247,8 @@ list(APPEND PLUGIN_SOURCES
   "cookie_manager.h"
   "platform_util.cpp"
   "platform_util.h"
+  "proxy_manager.cpp"
+  "proxy_manager.h"
 )
 
 # Define the plugin library target. Its name must not be changed (see comment

--- a/flutter_inappwebview_windows/windows/flutter_inappwebview_windows_plugin.cpp
+++ b/flutter_inappwebview_windows/windows/flutter_inappwebview_windows_plugin.cpp
@@ -7,6 +7,7 @@
 #include "in_app_browser/in_app_browser_manager.h"
 #include "in_app_webview/in_app_webview_manager.h"
 #include "platform_util.h"
+#include "proxy_manager.h"
 #include "webview_environment/webview_environment_manager.h"
 
 
@@ -35,6 +36,7 @@ namespace flutter_inappwebview_plugin
     headlessInAppWebViewManager = std::make_unique<HeadlessInAppWebViewManager>(this);
     cookieManager = std::make_unique<CookieManager>(this);
     platformUtil = std::make_unique<PlatformUtil>(this);
+    proxyManager = std::make_unique<ProxyManager>(this);
 
     window_proc_id = registrar->RegisterTopLevelWindowProcDelegate(
       [this](HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
@@ -54,6 +56,7 @@ namespace flutter_inappwebview_plugin
     headlessInAppWebViewManager = nullptr;
     cookieManager = nullptr;
     platformUtil = nullptr;
+    proxyManager = nullptr;
   }
 
 

--- a/flutter_inappwebview_windows/windows/flutter_inappwebview_windows_plugin.h
+++ b/flutter_inappwebview_windows/windows/flutter_inappwebview_windows_plugin.h
@@ -11,6 +11,7 @@ namespace flutter_inappwebview_plugin
   class HeadlessInAppWebViewManager;
   class CookieManager;
   class PlatformUtil;
+  class ProxyManager;
 
   class FlutterInappwebviewWindowsPlugin : public flutter::Plugin {
   public:
@@ -21,6 +22,7 @@ namespace flutter_inappwebview_plugin
     std::unique_ptr<HeadlessInAppWebViewManager> headlessInAppWebViewManager;
     std::unique_ptr<CookieManager> cookieManager;
     std::unique_ptr<PlatformUtil> platformUtil;
+    std::unique_ptr<ProxyManager> proxyManager;
 
     static void RegisterWithRegistrar(flutter::PluginRegistrarWindows* registrar);
 

--- a/flutter_inappwebview_windows/windows/headless_in_app_webview/headless_in_app_webview_manager.cpp
+++ b/flutter_inappwebview_windows/windows/headless_in_app_webview/headless_in_app_webview_manager.cpp
@@ -80,7 +80,7 @@ namespace flutter_inappwebview_plugin
 
     auto initialSettings = std::make_shared<InAppWebViewSettings>(settingsMap);
 
-    InAppWebView::createInAppWebViewEnv(hwnd, false, webViewEnvironment, initialSettings,
+    InAppWebView::createInAppWebViewEnv(plugin, hwnd, false, webViewEnvironment, initialSettings,
       [=](wil::com_ptr<ICoreWebView2Environment> webViewEnv,
         wil::com_ptr<ICoreWebView2Controller> webViewController,
         wil::com_ptr<ICoreWebView2CompositionController> webViewCompositionController)

--- a/flutter_inappwebview_windows/windows/in_app_browser/in_app_browser.cpp
+++ b/flutter_inappwebview_windows/windows/in_app_browser/in_app_browser.cpp
@@ -74,7 +74,7 @@ namespace flutter_inappwebview_plugin
     auto webViewEnvironment = params.webViewEnvironmentId.has_value() && map_contains(plugin->webViewEnvironmentManager->webViewEnvironments, params.webViewEnvironmentId.value())
       ? plugin->webViewEnvironmentManager->webViewEnvironments.at(params.webViewEnvironmentId.value()).get() : nullptr;
 
-    InAppWebView::createInAppWebViewEnv(m_hWnd, false, webViewEnvironment, params.initialWebViewSettings,
+    InAppWebView::createInAppWebViewEnv(plugin, m_hWnd, false, webViewEnvironment, params.initialWebViewSettings,
       [this, params, webViewParams](wil::com_ptr<ICoreWebView2Environment> webViewEnv, wil::com_ptr<ICoreWebView2Controller> webViewController, wil::com_ptr<ICoreWebView2CompositionController> webViewCompositionController) -> void
       {
         if (webViewEnv && webViewController) {

--- a/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview.cpp
+++ b/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview.cpp
@@ -3183,6 +3183,9 @@ namespace flutter_inappwebview_plugin
 
   bool InAppWebView::setVirtualHostNameToFolderMapping(const std::string& hostName, const std::string& folderPath, const int64_t& accessKind) const
   {
+    if (!webView) {
+      return false;
+    }
     wil::com_ptr<ICoreWebView2_3> webView3;
     if (FAILED(webView->QueryInterface(IID_PPV_ARGS(&webView3)))) {
       return false;

--- a/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview.cpp
+++ b/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview.cpp
@@ -39,6 +39,7 @@
 #include "../types/web_resource_request.h"
 #include "../utils/base64.h"
 #include "../utils/log.h"
+#include "../webview_environment/webview_environment_manager.h"
 #include "../utils/map.h"
 #include "../utils/strconv.h"
 #include "../utils/string.h"

--- a/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview.cpp
+++ b/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview.cpp
@@ -200,10 +200,7 @@ namespace flutter_inappwebview_plugin
       }
     }
     else if (plugin && plugin->webViewEnvironmentManager) {
-<<<<<<< HEAD
       // Через defaultEnvironment_ - подхватывает proxy args из ProxyManager
-=======
->>>>>>> 4baf2c469 (fix windows default WebViewEnvironment fallback)
       plugin->webViewEnvironmentManager->createOrGetDefaultWebViewEnvironment([callback, completionHandler](WebViewEnvironment* defaultEnv)
         {
           if (defaultEnv && defaultEnv->getEnvironment()) {

--- a/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview.cpp
+++ b/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview.cpp
@@ -92,7 +92,7 @@ namespace flutter_inappwebview_plugin
     this->inAppBrowser = inAppBrowser;
   }
 
-  void InAppWebView::createInAppWebViewEnv(const HWND parentWindow, const bool& willBeSurface, WebViewEnvironment* webViewEnvironment, const std::shared_ptr<InAppWebViewSettings> initialSettings, std::function<void(wil::com_ptr<ICoreWebView2Environment> webViewEnv,
+  void InAppWebView::createInAppWebViewEnv(const FlutterInappwebviewWindowsPlugin* plugin, const HWND parentWindow, const bool& willBeSurface, WebViewEnvironment* webViewEnvironment, const std::shared_ptr<InAppWebViewSettings> initialSettings, std::function<void(wil::com_ptr<ICoreWebView2Environment> webViewEnv,
     wil::com_ptr<ICoreWebView2Controller> webViewController,
     wil::com_ptr<ICoreWebView2CompositionController> webViewCompositionController)> completionHandler)
   {
@@ -200,7 +200,10 @@ namespace flutter_inappwebview_plugin
       }
     }
     else if (plugin && plugin->webViewEnvironmentManager) {
+<<<<<<< HEAD
       // Через defaultEnvironment_ - подхватывает proxy args из ProxyManager
+=======
+>>>>>>> 4baf2c469 (fix windows default WebViewEnvironment fallback)
       plugin->webViewEnvironmentManager->createOrGetDefaultWebViewEnvironment([callback, completionHandler](WebViewEnvironment* defaultEnv)
         {
           if (defaultEnv && defaultEnv->getEnvironment()) {

--- a/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview.cpp
+++ b/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview.cpp
@@ -192,17 +192,28 @@ namespace flutter_inappwebview_plugin
         return S_OK;
       };
 
-    HRESULT hr;
     if (webViewEnvironment && webViewEnvironment->getEnvironment()) {
-      hr = callback(S_OK, webViewEnvironment->getEnvironment());
+      auto hr = callback(S_OK, webViewEnvironment->getEnvironment());
+      if (failedAndLog(hr)) {
+        completionHandler(nullptr, nullptr, nullptr);
+      }
+    }
+    else if (plugin && plugin->webViewEnvironmentManager) {
+      // Через defaultEnvironment_ - подхватывает proxy args из ProxyManager
+      plugin->webViewEnvironmentManager->createOrGetDefaultWebViewEnvironment([callback, completionHandler](WebViewEnvironment* defaultEnv)
+        {
+          if (defaultEnv && defaultEnv->getEnvironment()) {
+            auto hr = callback(S_OK, defaultEnv->getEnvironment());
+            if (failedAndLog(hr)) {
+              completionHandler(nullptr, nullptr, nullptr);
+            }
+          }
+          else {
+            completionHandler(nullptr, nullptr, nullptr);
+          }
+        });
     }
     else {
-      hr = CreateCoreWebView2EnvironmentWithOptions(
-        nullptr, nullptr, nullptr,
-        Callback<ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler>(callback).Get());
-    }
-
-    if (failedAndLog(hr)) {
       completionHandler(nullptr, nullptr, nullptr);
     }
   }

--- a/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview.cpp
+++ b/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview.cpp
@@ -3181,6 +3181,18 @@ namespace flutter_inappwebview_plugin
     }
   }
 
+  bool InAppWebView::setVirtualHostNameToFolderMapping(const std::string& hostName, const std::string& folderPath, const int64_t& accessKind) const
+  {
+    wil::com_ptr<ICoreWebView2_3> webView3;
+    if (FAILED(webView->QueryInterface(IID_PPV_ARGS(&webView3)))) {
+      return false;
+    }
+    return succeededOrLog(webView3->SetVirtualHostNameToFolderMapping(
+      utf8_to_wide(hostName).c_str(),
+      utf8_to_wide(folderPath).c_str(),
+      static_cast<COREWEBVIEW2_HOST_RESOURCE_ACCESS_KIND>(accessKind)));
+  }
+
 
   void InAppWebView::getCertificate(const std::function<void(const std::optional<std::unique_ptr<SslCertificate>>)> completionHandler) const
   {

--- a/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview.h
+++ b/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview.h
@@ -192,6 +192,7 @@ namespace flutter_inappwebview_plugin
     void removeDevToolsProtocolEventListener(const std::string& eventName);
     void pause() const;
     void resume() const;
+    bool setVirtualHostNameToFolderMapping(const std::string& hostName, const std::string& folderPath, const int64_t& accessKind) const;
     void getCertificate(const std::function<void(const std::optional<std::unique_ptr<SslCertificate>>)> completionHandler) const;
     void clearSslPreferences(const std::function<void()> completionHandler) const;
     bool isInterfaceSupported(const std::string& interfaceName) const;

--- a/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview.h
+++ b/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview.h
@@ -123,7 +123,7 @@ namespace flutter_inappwebview_plugin
       wil::com_ptr<ICoreWebView2CompositionController> webViewCompositionController);
     ~InAppWebView();
 
-    static void createInAppWebViewEnv(const HWND parentWindow, const bool& willBeSurface, WebViewEnvironment* webViewEnvironment, const std::shared_ptr<InAppWebViewSettings> initialSettings, std::function<void(wil::com_ptr<ICoreWebView2Environment> webViewEnv,
+    static void createInAppWebViewEnv(const FlutterInappwebviewWindowsPlugin* plugin, const HWND parentWindow, const bool& willBeSurface, WebViewEnvironment* webViewEnvironment, const std::shared_ptr<InAppWebViewSettings> initialSettings, std::function<void(wil::com_ptr<ICoreWebView2Environment> webViewEnv,
       wil::com_ptr<ICoreWebView2Controller> webViewController,
       wil::com_ptr<ICoreWebView2CompositionController> webViewCompositionController)> completionHandler);
 

--- a/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview_manager.cpp
+++ b/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview_manager.cpp
@@ -148,7 +148,7 @@ namespace flutter_inappwebview_plugin
 
     auto initialSettings = std::make_shared<InAppWebViewSettings>(settingsMap);
 
-    InAppWebView::createInAppWebViewEnv(hwnd, true, webViewEnvironment, initialSettings,
+    InAppWebView::createInAppWebViewEnv(plugin, hwnd, true, webViewEnvironment, initialSettings,
       [=](wil::com_ptr<ICoreWebView2Environment> webViewEnv,
         wil::com_ptr<ICoreWebView2Controller> webViewController,
         wil::com_ptr<ICoreWebView2CompositionController> webViewCompositionController)

--- a/flutter_inappwebview_windows/windows/in_app_webview/webview_channel_delegate.cpp
+++ b/flutter_inappwebview_windows/windows/in_app_webview/webview_channel_delegate.cpp
@@ -388,6 +388,12 @@ namespace flutter_inappwebview_plugin
       webView->resume();
       result->Success(true);
     }
+    else if (string_equals(methodName, "setVirtualHostNameToFolderMapping")) {
+      auto hostName = get_fl_map_value<std::string>(arguments, "hostName");
+      auto folderPath = get_fl_map_value<std::string>(arguments, "folderPath");
+      auto accessKind = get_fl_map_value<int64_t>(arguments, "accessKind");
+      result->Success(webView->setVirtualHostNameToFolderMapping(hostName, folderPath, accessKind));
+    }
     else if (string_equals(methodName, "getCertificate")) {
       auto result_ = std::shared_ptr<flutter::MethodResult<flutter::EncodableValue>>(std::move(result));
       webView->getCertificate([result_ = std::move(result_)](const std::optional<std::unique_ptr<SslCertificate>> data)

--- a/flutter_inappwebview_windows/windows/proxy_manager.cpp
+++ b/flutter_inappwebview_windows/windows/proxy_manager.cpp
@@ -1,0 +1,152 @@
+#include "proxy_manager.h"
+#include "utils/flutter.h"
+#include "utils/log.h"
+#include "utils/string.h"
+
+namespace flutter_inappwebview_plugin
+{
+  // === ProxySettings ===
+
+  ProxySettings::ProxySettings(const flutter::EncodableMap& map)
+  {
+    if (fl_map_contains_not_null(map, "bypassRules")) {
+      auto bypassList = std::get<flutter::EncodableList>(map.at(make_fl_value("bypassRules")));
+      for (const auto& item : bypassList) {
+        if (auto* str = std::get_if<std::string>(&item)) {
+          bypassRules.push_back(*str);
+        }
+      }
+    }
+
+    if (fl_map_contains_not_null(map, "proxyRules")) {
+      auto rulesList = std::get<flutter::EncodableList>(map.at(make_fl_value("proxyRules")));
+      for (const auto& item : rulesList) {
+        if (auto* ruleMap = std::get_if<flutter::EncodableMap>(&item)) {
+          ProxyRule rule;
+          rule.url = get_fl_map_value<std::string>(*ruleMap, "url");
+
+          if (fl_map_contains_not_null(*ruleMap, "schemeFilter")) {
+            auto schemeFilterValue = ruleMap->at(make_fl_value("schemeFilter"));
+            if (auto* schemeMap = std::get_if<flutter::EncodableMap>(&schemeFilterValue)) {
+              if (fl_map_contains_not_null(*schemeMap, "rawValue")) {
+                rule.schemeFilter = get_fl_map_value<std::string>(*schemeMap, "rawValue");
+              }
+            } else if (auto* str = std::get_if<std::string>(&schemeFilterValue)) {
+              rule.schemeFilter = *str;
+            }
+          }
+
+          proxyRules.push_back(std::move(rule));
+        }
+      }
+    }
+  }
+
+  std::optional<std::string> ProxySettings::toProxyServerArg() const
+  {
+    if (proxyRules.empty()) {
+      return std::nullopt;
+    }
+
+    // WebView2 --proxy-server format:
+    // Single proxy: "host:port"
+    // Per-scheme: "http=proxy1:80;https=proxy2:443;socks=socks5://proxy3:1080"
+    std::string defaultProxy;
+    std::vector<std::string> schemeProxies;
+
+    for (const auto& rule : proxyRules) {
+      if (!rule.schemeFilter.has_value() || rule.schemeFilter.value().empty()) {
+        if (defaultProxy.empty()) {
+          defaultProxy = rule.url;
+        }
+        continue;
+      }
+
+      std::string scheme = rule.schemeFilter.value();
+      std::transform(scheme.begin(), scheme.end(), scheme.begin(),
+        [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+      if (scheme == "*") {
+        if (defaultProxy.empty()) {
+          defaultProxy = rule.url;
+        }
+      } else {
+        schemeProxies.push_back(scheme + "=" + rule.url);
+      }
+    }
+
+    if (schemeProxies.empty()) {
+      return defaultProxy.empty() ? std::nullopt : std::optional<std::string>(defaultProxy);
+    }
+
+    // If we have a default proxy and scheme-specific, combine them
+    std::string result;
+    if (!defaultProxy.empty()) {
+      result = defaultProxy;
+    }
+    for (const auto& sp : schemeProxies) {
+      if (!result.empty()) {
+        result += ";";
+      }
+      result += sp;
+    }
+
+    return result.empty() ? std::nullopt : std::optional<std::string>(result);
+  }
+
+  std::optional<std::string> ProxySettings::toProxyBypassListArg() const
+  {
+    if (bypassRules.empty()) {
+      return std::nullopt;
+    }
+
+    std::string result;
+    for (const auto& rule : bypassRules) {
+      if (!result.empty()) {
+        result += ";";
+      }
+      result += rule;
+    }
+
+    return result;
+  }
+
+  // === ProxyManager ===
+
+  ProxyManager::ProxyManager(const FlutterInappwebviewWindowsPlugin* plugin)
+    : plugin(plugin), ChannelDelegate(plugin->registrar->messenger(), ProxyManager::METHOD_CHANNEL_NAME)
+  {}
+
+  void ProxyManager::HandleMethodCall(const flutter::MethodCall<flutter::EncodableValue>& method_call,
+    std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result)
+  {
+    auto& methodName = method_call.method_name();
+
+    if (string_equals(methodName, "setProxyOverride")) {
+      auto* arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
+      if (arguments && fl_map_contains_not_null(*arguments, "settings")) {
+        auto settingsMap = std::get<flutter::EncodableMap>(arguments->at(make_fl_value("settings")));
+        ProxySettings settings(settingsMap);
+        proxyServerArg_ = settings.toProxyServerArg();
+        proxyBypassListArg_ = settings.toProxyBypassListArg();
+        result->Success(true);
+      } else {
+        result->Success(false);
+      }
+    }
+    else if (string_equals(methodName, "clearProxyOverride")) {
+      proxyServerArg_ = std::nullopt;
+      proxyBypassListArg_ = std::nullopt;
+      result->Success(true);
+    }
+    else {
+      result->NotImplemented();
+    }
+  }
+
+  ProxyManager::~ProxyManager()
+  {
+    debugLog("dealloc ProxyManager");
+    plugin = nullptr;
+  }
+}

--- a/flutter_inappwebview_windows/windows/proxy_manager.cpp
+++ b/flutter_inappwebview_windows/windows/proxy_manager.cpp
@@ -1,3 +1,6 @@
+#include <algorithm>
+#include <cctype>
+
 #include "proxy_manager.h"
 #include "utils/flutter.h"
 #include "utils/log.h"

--- a/flutter_inappwebview_windows/windows/proxy_manager.h
+++ b/flutter_inappwebview_windows/windows/proxy_manager.h
@@ -1,0 +1,60 @@
+#ifndef FLUTTER_INAPPWEBVIEW_PLUGIN_PROXY_MANAGER_H_
+#define FLUTTER_INAPPWEBVIEW_PLUGIN_PROXY_MANAGER_H_
+
+#include <flutter/encodable_value.h>
+#include <flutter/method_channel.h>
+#include <functional>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "flutter_inappwebview_windows_plugin.h"
+#include "types/channel_delegate.h"
+
+namespace flutter_inappwebview_plugin
+{
+  struct ProxyRule
+  {
+    std::string url;
+    std::optional<std::string> schemeFilter;
+  };
+
+  struct ProxySettings
+  {
+    std::vector<std::string> bypassRules;
+    std::vector<ProxyRule> proxyRules;
+
+    ProxySettings() = default;
+    ProxySettings(const flutter::EncodableMap& map);
+
+    // WebView2 --proxy-server argument (e.g. "http=proxy:80;https=proxy:443")
+    std::optional<std::string> toProxyServerArg() const;
+    // WebView2 --proxy-bypass-list argument (e.g. "host1;host2")
+    std::optional<std::string> toProxyBypassListArg() const;
+  };
+
+  class ProxyManager : public ChannelDelegate
+  {
+  public:
+    static inline const std::string METHOD_CHANNEL_NAME = "com.pichillilorenzo/flutter_inappwebview_proxycontroller";
+
+    const FlutterInappwebviewWindowsPlugin* plugin;
+
+    ProxyManager(const FlutterInappwebviewWindowsPlugin* plugin);
+    ~ProxyManager();
+
+    void HandleMethodCall(
+      const flutter::MethodCall<flutter::EncodableValue>& method_call,
+      std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+
+    // Stored proxy args for use by WebViewEnvironment
+    std::optional<std::string> getProxyServerArg() const { return proxyServerArg_; }
+    std::optional<std::string> getProxyBypassListArg() const { return proxyBypassListArg_; }
+
+  private:
+    std::optional<std::string> proxyServerArg_;
+    std::optional<std::string> proxyBypassListArg_;
+  };
+}
+
+#endif //FLUTTER_INAPPWEBVIEW_PLUGIN_PROXY_MANAGER_H_

--- a/flutter_inappwebview_windows/windows/webview_environment/webview_environment.cpp
+++ b/flutter_inappwebview_windows/windows/webview_environment/webview_environment.cpp
@@ -1,6 +1,7 @@
 #include <WebView2EnvironmentOptions.h>
 #include <wil/wrl.h>
 
+#include "../proxy_manager.h"
 #include "../utils/log.h"
 #include "webview_environment.h"
 
@@ -33,10 +34,37 @@ namespace flutter_inappwebview_plugin
     }
 
     auto options = Make<CoreWebView2EnvironmentOptions>();
-    if (settings) {
-      if (settings->additionalBrowserArguments.has_value()) {
-        options->put_AdditionalBrowserArguments(utf8_to_wide(settings->additionalBrowserArguments.value()).c_str());
+
+    // Inject proxy args from ProxyManager if set
+    {
+      std::wstring browserArgs;
+      if (settings && settings->additionalBrowserArguments.has_value()) {
+        browserArgs = utf8_to_wide(settings->additionalBrowserArguments.value());
       }
+
+      if (plugin->proxyManager) {
+        auto proxyServer = plugin->proxyManager->getProxyServerArg();
+        if (proxyServer.has_value()) {
+          if (!browserArgs.empty()) {
+            browserArgs += L" ";
+          }
+          browserArgs += L"--proxy-server=" + utf8_to_wide(proxyServer.value());
+        }
+        auto proxyBypass = plugin->proxyManager->getProxyBypassListArg();
+        if (proxyBypass.has_value()) {
+          if (!browserArgs.empty()) {
+            browserArgs += L" ";
+          }
+          browserArgs += L"--proxy-bypass-list=" + utf8_to_wide(proxyBypass.value());
+        }
+      }
+
+      if (!browserArgs.empty()) {
+        options->put_AdditionalBrowserArguments(browserArgs.c_str());
+      }
+    }
+
+    if (settings) {
       if (settings->allowSingleSignOnUsingOSPrimaryAccount.has_value()) {
         options->put_AllowSingleSignOnUsingOSPrimaryAccount(settings->allowSingleSignOnUsingOSPrimaryAccount.value());
       }


### PR DESCRIPTION
Closes #2805

## Summary

Adds `ProxyController` implementation for Windows using WebView2's `--proxy-server` browser argument.

**Changes:**

- **C++ `ProxyManager`** (`proxy_manager.h/.cpp`) — handles `setProxyOverride`/`clearProxyOverride` method channel calls, converts `ProxySettings` to `--proxy-server` and `--proxy-bypass-list` args
- **Proxy injection in `WebViewEnvironment::create()`** — proxy args are appended to `additionalBrowserArguments` when creating the WebView2 environment
- **Default env routing** (`in_app_webview.cpp`) — fallback from raw `CreateCoreWebView2EnvironmentWithOptions(nullptr, nullptr, nullptr)` to `WebViewEnvironmentManager::createOrGetDefaultWebViewEnvironment()` so proxy args are picked up
- **Dart `WindowsProxyController`** — extends `PlatformProxyController` with MethodChannel bridge, registered in `WindowsInAppWebViewPlatform`
- **Platform Interface** — `WindowsPlatform` added to `@SupportedPlatforms` for ProxyController, ProxySettings, and related methods/properties
- **Local path deps** — all sub-packages use local `path:` dependencies for `flutter_inappwebview_platform_interface`

## Limitations

- Proxy is set at WebView2 environment creation time via browser args — cannot be changed at runtime (WebView2 limitation)
- `setProxyOverride()` must be called before WebView creation

## Test plan

- [x] Unit tests for `WindowsProxyController` (9 tests: method channel calls, ProxySettings roundtrip, isClassSupported)
- [ ] Manual test on Windows: set proxy, open WebView, verify traffic goes through proxy
- [ ] Verify Android/iOS/macOS/Linux ProxyController still works (no regressions)