### PR TITLE
Fix macOS Compile Failure "WebAuthenticationSession.swift:85:17: Protocol 'ASWebAuthenticationPresentationContextProviding' requires 'presentationAnchor(for:)' to be available in macOS 10.14 and newer"

### DIFF
--- a/flutter_inappwebview_ios/ios/flutter_inappwebview_ios/Sources/flutter_inappwebview_ios/WebAuthenticationSession/WebAuthenticationSession.swift
+++ b/flutter_inappwebview_ios/ios/flutter_inappwebview_ios/Sources/flutter_inappwebview_ios/WebAuthenticationSession/WebAuthenticationSession.swift
@@ -10,7 +10,15 @@ import AuthenticationServices
 import SafariServices
 import Flutter
 
-public class WebAuthenticationSession: NSObject, ASWebAuthenticationPresentationContextProviding, Disposable {
+@available(iOS 13.0, *)
+private class WebAuthenticationPresentationContextProviding: NSObject, ASWebAuthenticationPresentationContextProviding {
+    
+    public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        return UIApplication.shared.windows.first { $0.isKeyWindow } ?? ASPresentationAnchor()
+    }
+}
+
+public class WebAuthenticationSession: NSObject, Disposable {
     static let METHOD_CHANNEL_NAME_PREFIX = "com.pichillilorenzo/flutter_webauthenticationsession_"
     var id: String
     var plugin: InAppWebViewFlutterPlugin?
@@ -20,6 +28,8 @@ public class WebAuthenticationSession: NSObject, ASWebAuthenticationPresentation
     var session: Any?
     var channelDelegate: WebAuthenticationSessionChannelDelegate?
     private var _canStart = true
+    // keep reference
+    private var _presentationContextProvider: Any?
     
     public init(plugin: InAppWebViewFlutterPlugin, id: String, url: URL, callbackURLScheme: String?, settings: WebAuthenticationSessionSettings) {
         self.id = id
@@ -31,7 +41,10 @@ public class WebAuthenticationSession: NSObject, ASWebAuthenticationPresentation
         if #available(iOS 12.0, *) {
             let session = ASWebAuthenticationSession(url: self.url, callbackURLScheme: self.callbackURLScheme, completionHandler: self.completionHandler)
             if #available(iOS 13.0, *) {
-                session.presentationContextProvider = self
+                let auth = WebAuthenticationPresentationContextProviding()
+                // keep reference
+                self._presentationContextProvider = auth
+                session.presentationContextProvider = auth
             }
             self.session = session
         } else if #available(iOS 11.0, *) {
@@ -87,11 +100,6 @@ public class WebAuthenticationSession: NSObject, ASWebAuthenticationPresentation
         } else if #available(iOS 11.0, *), let session = session as? SFAuthenticationSession {
             session.cancel()
         }
-    }
-    
-    @available(iOS 12.0, *)
-    public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        return UIApplication.shared.windows.first { $0.isKeyWindow } ?? ASPresentationAnchor()
     }
     
     public func dispose() {

--- a/flutter_inappwebview_ios/ios/flutter_inappwebview_ios/Sources/flutter_inappwebview_ios/WebAuthenticationSession/WebAuthenticationSession.swift
+++ b/flutter_inappwebview_ios/ios/flutter_inappwebview_ios/Sources/flutter_inappwebview_ios/WebAuthenticationSession/WebAuthenticationSession.swift
@@ -41,10 +41,10 @@ public class WebAuthenticationSession: NSObject, Disposable {
         if #available(iOS 12.0, *) {
             let session = ASWebAuthenticationSession(url: self.url, callbackURLScheme: self.callbackURLScheme, completionHandler: self.completionHandler)
             if #available(iOS 13.0, *) {
-                let auth = WebAuthenticationPresentationContextProviding()
+                let provider = WebAuthenticationPresentationContextProviding()
                 // keep reference
-                self._presentationContextProvider = auth
-                session.presentationContextProvider = auth
+                self._presentationContextProvider = provider
+                session.presentationContextProvider = provider
             }
             self.session = session
         } else if #available(iOS 11.0, *) {

--- a/flutter_inappwebview_macos/macos/flutter_inappwebview_macos/Sources/flutter_inappwebview_macos/WebAuthenticationSession/WebAuthenticationSession.swift
+++ b/flutter_inappwebview_macos/macos/flutter_inappwebview_macos/Sources/flutter_inappwebview_macos/WebAuthenticationSession/WebAuthenticationSession.swift
@@ -40,10 +40,10 @@ public class WebAuthenticationSession: NSObject, Disposable {
         self.callbackURLScheme = callbackURLScheme
         if #available(macOS 10.15, *) {
             let session = ASWebAuthenticationSession(url: self.url, callbackURLScheme: self.callbackURLScheme, completionHandler: self.completionHandler)
-            let auth = WebAuthenticationPresentationContextProviding()
+            let provider = WebAuthenticationPresentationContextProviding()
             // keep reference
-            self._presentationContextProvider = auth
-            session.presentationContextProvider = auth
+            self._presentationContextProvider = provider
+            session.presentationContextProvider = provider
             self.session = session
         }
         let channel = FlutterMethodChannel(name: WebAuthenticationSession.METHOD_CHANNEL_NAME_PREFIX + id,

--- a/flutter_inappwebview_macos/macos/flutter_inappwebview_macos/Sources/flutter_inappwebview_macos/WebAuthenticationSession/WebAuthenticationSession.swift
+++ b/flutter_inappwebview_macos/macos/flutter_inappwebview_macos/Sources/flutter_inappwebview_macos/WebAuthenticationSession/WebAuthenticationSession.swift
@@ -28,6 +28,8 @@ public class WebAuthenticationSession: NSObject, Disposable {
     var session: Any?
     var channelDelegate: WebAuthenticationSessionChannelDelegate?
     private var _canStart = true
+    // keep reference
+    private var _presentationContextProvider: Any?
     
     public init(plugin: InAppWebViewFlutterPlugin, id: String, url: URL, callbackURLScheme: String?, settings: WebAuthenticationSessionSettings) {
         self.id = id
@@ -38,7 +40,10 @@ public class WebAuthenticationSession: NSObject, Disposable {
         self.callbackURLScheme = callbackURLScheme
         if #available(macOS 10.15, *) {
             let session = ASWebAuthenticationSession(url: self.url, callbackURLScheme: self.callbackURLScheme, completionHandler: self.completionHandler)
-            session.presentationContextProvider = WebAuthenticationPresentationContextProviding()
+            let auth = WebAuthenticationPresentationContextProviding()
+            // keep reference
+            self._presentationContextProvider = auth
+            session.presentationContextProvider = auth
             self.session = session
         }
         let channel = FlutterMethodChannel(name: WebAuthenticationSession.METHOD_CHANNEL_NAME_PREFIX + id,

--- a/flutter_inappwebview_macos/macos/flutter_inappwebview_macos/Sources/flutter_inappwebview_macos/WebAuthenticationSession/WebAuthenticationSession.swift
+++ b/flutter_inappwebview_macos/macos/flutter_inappwebview_macos/Sources/flutter_inappwebview_macos/WebAuthenticationSession/WebAuthenticationSession.swift
@@ -10,7 +10,15 @@ import AuthenticationServices
 import SafariServices
 import FlutterMacOS
 
-public class WebAuthenticationSession: NSObject, ASWebAuthenticationPresentationContextProviding, Disposable {
+@available(macOS 10.15, *)
+private class WebAuthenticationPresentationContextProviding: NSObject, ASWebAuthenticationPresentationContextProviding {
+    
+    public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        return NSApplication.shared.windows.first { $0.isKeyWindow } ?? ASPresentationAnchor()
+    }
+}
+
+public class WebAuthenticationSession: NSObject, Disposable {
     static let METHOD_CHANNEL_NAME_PREFIX = "com.pichillilorenzo/flutter_webauthenticationsession_"
     var id: String
     var plugin: InAppWebViewFlutterPlugin?
@@ -30,7 +38,7 @@ public class WebAuthenticationSession: NSObject, ASWebAuthenticationPresentation
         self.callbackURLScheme = callbackURLScheme
         if #available(macOS 10.15, *) {
             let session = ASWebAuthenticationSession(url: self.url, callbackURLScheme: self.callbackURLScheme, completionHandler: self.completionHandler)
-            session.presentationContextProvider = self
+            session.presentationContextProvider = WebAuthenticationPresentationContextProviding()
             self.session = session
         }
         let channel = FlutterMethodChannel(name: WebAuthenticationSession.METHOD_CHANNEL_NAME_PREFIX + id,
@@ -79,11 +87,6 @@ public class WebAuthenticationSession: NSObject, ASWebAuthenticationPresentation
         if #available(macOS 10.15, *), let session = session as? ASWebAuthenticationSession {
             session.cancel()
         }
-    }
-    
-    @available(macOS 10.15, *)
-    public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        return NSApplication.shared.windows.first { $0.isKeyWindow } ?? ASPresentationAnchor()
     }
     
     public func dispose() {


### PR DESCRIPTION
## Connection with issue(s)

macOS 26.4 Xcode 26.4  compile failure  

Resolve issue #???

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->

Connected to #???

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->

## Testing and Review Notes

<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->


## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [x] double check the original issue to confirm it is fully satisfied
