### PR TITLE
fix(windows): prevent crash on app exit caused

### DIFF
--- a/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview_manager.cpp
+++ b/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview_manager.cpp
@@ -1,7 +1,9 @@
 #include <DispatcherQueue.h>
 #include <flutter/method_channel.h>
 #include <flutter/standard_method_codec.h>
+#include <cassert>
 #include <shlobj.h>
+#include <windows.foundation.h>
 #include <windows.graphics.capture.h>
 
 #include "../in_app_webview/in_app_webview_settings.h"
@@ -21,34 +23,35 @@ namespace flutter_inappwebview_plugin
     : plugin(plugin),
     ChannelDelegate(plugin->registrar->messenger(), InAppWebViewManager::METHOD_CHANNEL_NAME)
   {
-    if (!rohelper_) {
-      rohelper_ = std::make_unique<rx::RoHelper>(RO_INIT_SINGLETHREADED);
+    {
+      const std::lock_guard<std::mutex> lock(shared_resources_mutex_);
+      ++instance_count_;
 
-      if (rohelper_->WinRtAvailable()) {
-        DispatcherQueueOptions options{ sizeof(DispatcherQueueOptions),
-                                       DQTYPE_THREAD_CURRENT, DQTAT_COM_STA };
+      if (!rohelper_) {
+        rohelper_ = new rx::RoHelper(RO_INIT_SINGLETHREADED);
 
-        if (FAILED(rohelper_->CreateDispatcherQueueController(
-          options, dispatcher_queue_controller_.put()))) {
-          std::cerr << "Creating DispatcherQueueController failed." << std::endl;
-          return;
+        if (rohelper_->WinRtAvailable()) {
+          DispatcherQueueOptions options{ sizeof(DispatcherQueueOptions),
+                                         DQTYPE_THREAD_CURRENT, DQTAT_COM_STA };
+
+          if (FAILED(rohelper_->CreateDispatcherQueueController(
+            options, &dispatcher_queue_controller_))) {
+            std::cerr << "Creating DispatcherQueueController failed." << std::endl;
+            return;
+          }
+
+          if (!isGraphicsCaptureSessionSupported()) {
+            std::cerr << "Windows::Graphics::Capture::GraphicsCaptureSession is not "
+              "supported."
+              << std::endl;
+            return;
+          }
+
+          graphics_context_ = new GraphicsContext(rohelper_);
+          auto compositor = graphics_context_->CreateCompositor();
+          compositor_ = compositor.detach();
+          valid_ = graphics_context_->IsValid();
         }
-
-        if (!isGraphicsCaptureSessionSupported()) {
-          std::cerr << "Windows::Graphics::Capture::GraphicsCaptureSession is not "
-            "supported."
-            << std::endl;
-          return;
-        }
-
-        graphics_context_ = std::make_unique<GraphicsContext>(rohelper_.get());
-        compositor_ = graphics_context_->CreateCompositor();
-        if (compositor_) {
-          // fix for KernelBase.dll RaiseFailFastException
-          // when app is closing 
-          compositor_->AddRef();
-        }
-        valid_ = graphics_context_->IsValid();
       }
     }
 
@@ -250,6 +253,34 @@ namespace flutter_inappwebview_plugin
     return !!is_supported;
   }
 
+  ABI::Windows::System::IDispatcherQueueController* InAppWebViewManager::detachSharedResourcesForShutdown()
+  {
+    // These WinRT/Composition objects are intentionally process-lifetime
+    // objects. Releasing them during Flutter engine teardown can call into
+    // WinRT DLLs while they are unloading. Null the cached pointers so the
+    // plugin won't use them again; the OS will reclaim them at process exit.
+    valid_ = false;
+    const auto dispatcherQueueController = dispatcher_queue_controller_;
+    dispatcher_queue_controller_ = nullptr;
+    compositor_ = nullptr;
+    graphics_context_ = nullptr;
+    rohelper_ = nullptr;
+    return dispatcherQueueController;
+  }
+
+  void InAppWebViewManager::shutdownDispatcherQueue(ABI::Windows::System::IDispatcherQueueController* dispatcherQueueController)
+  {
+    if (!dispatcherQueueController) {
+      return;
+    }
+
+    ABI::Windows::Foundation::IAsyncAction* shutdownOperation = nullptr;
+    failedLog(dispatcherQueueController->ShutdownQueueAsync(&shutdownOperation));
+    // Do not release the async operation during shutdown; keep it alive for
+    // the remaining process lifetime so it cannot race with queue shutdown.
+    (void)shutdownOperation;
+  }
+
   InAppWebViewManager::~InAppWebViewManager()
   {
     debugLog("dealloc InAppWebViewManager");
@@ -258,5 +289,17 @@ namespace flutter_inappwebview_plugin
     windowWebViews.clear();
     UnregisterClass(windowClass_.lpszClassName, nullptr);
     plugin = nullptr;
+
+    ABI::Windows::System::IDispatcherQueueController* dispatcherQueueController = nullptr;
+    {
+      const std::lock_guard<std::mutex> lock(shared_resources_mutex_);
+      assert(instance_count_ > 0);
+      --instance_count_;
+      if (instance_count_ == 0) {
+        dispatcherQueueController = detachSharedResourcesForShutdown();
+      }
+    }
+
+    shutdownDispatcherQueue(dispatcherQueueController);
   }
 }

--- a/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview_manager.h
+++ b/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview_manager.h
@@ -3,7 +3,9 @@
 
 #include <flutter/method_channel.h>
 #include <flutter/standard_message_codec.h>
+#include <cstddef>
 #include <map>
+#include <mutex>
 #include <string>
 #include <variant>
 #include <wil/com.h>
@@ -34,12 +36,16 @@ namespace flutter_inappwebview_plugin
     bool isGraphicsCaptureSessionSupported();
     GraphicsContext* graphics_context() const
     {
-      return graphics_context_.get();
+      return graphics_context_;
     };
-    rx::RoHelper* rohelper() const { return rohelper_.get(); }
+    rx::RoHelper* rohelper() const { return rohelper_; }
     winrt::com_ptr<ABI::Windows::UI::Composition::ICompositor> compositor() const
     {
-      return compositor_;
+      winrt::com_ptr<ABI::Windows::UI::Composition::ICompositor> compositor;
+      if (compositor_) {
+        compositor.copy_from(compositor_);
+      }
+      return compositor;
     }
 
     InAppWebViewManager(const FlutterInappwebviewWindowsPlugin* plugin);
@@ -52,13 +58,17 @@ namespace flutter_inappwebview_plugin
     void createInAppWebView(const flutter::EncodableMap* arguments, std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
     void disposeKeepAlive(const std::string& keepAliveId);
   private:
-    inline static std::shared_ptr<rx::RoHelper> rohelper_ = nullptr;
-    inline static winrt::com_ptr<ABI::Windows::System::IDispatcherQueueController>
-      dispatcher_queue_controller_;
-    inline static std::unique_ptr<GraphicsContext> graphics_context_ = nullptr;
-    inline static winrt::com_ptr<ABI::Windows::UI::Composition::ICompositor> compositor_;
+    inline static rx::RoHelper* rohelper_ = nullptr;
+    inline static ABI::Windows::System::IDispatcherQueueController* dispatcher_queue_controller_ = nullptr;
+    inline static GraphicsContext* graphics_context_ = nullptr;
+    inline static ABI::Windows::UI::Composition::ICompositor* compositor_ = nullptr;
     WNDCLASS windowClass_ = {};
     inline static bool valid_ = false;
+    inline static std::size_t instance_count_ = 0;
+    inline static std::mutex shared_resources_mutex_;
+
+    static ABI::Windows::System::IDispatcherQueueController* detachSharedResourcesForShutdown();
+    static void shutdownDispatcherQueue(ABI::Windows::System::IDispatcherQueueController* dispatcherQueueController);
   };
 }
 #endif //FLUTTER_INAPPWEBVIEW_PLUGIN_IN_APP_WEBVIEW_MANAGER_H_


### PR DESCRIPTION
fix(windows): prevent crash on app exit caused by WinRT COM release during DLL unload

Static WinRT/Composition objects (ICompositor, IDispatcherQueueController, GraphicsContext, RoHelper) were held in static smart pointers (winrt::com_ptr, std::unique_ptr, std::shared_ptr). Their destructors called Release() and RoUninitialize() during DLL_PROCESS_DETACH, after the WinRT DLLs had already started unloading, triggering RaiseFailFastException in KernelBase.dll and causing Windows Error Reporting to appear on exit.

Changes:
- Convert all four static WinRT/COM resource pointers to raw pointers so no RAII destructor runs Release() or RoUninitialize() at static-destruction time; the OS reclaims them at process exit instead.
- Add instance_count_ (protected by shared_resources_mutex_) to track the number of live InAppWebViewManager instances and trigger cleanup only when the last one is destroyed.
- Add detachSharedResourcesForShutdown() which nulls all raw pointers under the mutex (without delete/Release) and returns the dispatcher queue controller for subsequent use.
- Add shutdownDispatcherQueue() which calls ShutdownQueueAsync() outside the mutex and intentionally leaks both the IAsyncAction and the controller as process-lifetime objects, avoiding any Release() race with WinRT teardown.
- Remove the earlier AddRef() workaround on ICompositor, which did not actually prevent the crash.
- Replace the std::unique_ptr/shared_ptr allocations of RoHelper and GraphicsContext with raw new, consistent with the process-lifetime-leak design for all shared resources.

Fixes: https://github.com/pichillilorenzo/flutter_inappwebview/issues/2733

## Connection with issue(s)

Resolve issue #???

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->

Connected to #???

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->

## Testing and Review Notes

<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->


## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable)
