### PR TITLE
[Android] Defer JS bridge native registrations off platform-view attach

### DIFF
--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/types/UserContentController.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/types/UserContentController.java
@@ -2,6 +2,7 @@ package com.pichillilorenzo.flutter_inappwebview_android.types;
 
 import android.annotation.SuppressLint;
 import android.text.TextUtils;
+import android.util.Log;
 import android.webkit.WebView;
 
 import androidx.annotation.NonNull;
@@ -210,12 +211,22 @@ public class UserContentController implements Disposable {
       }
       source = wrapSourceCodeAddChecks(source, userOnlyScript);
 
-      ScriptHandler scriptHandler = WebViewCompat.addDocumentStartJavaScript(
-              webView,
-              wrapSourceCodeInContentWorld(userOnlyScript.getContentWorld(), source),
-              userOnlyScript.getAllowedOriginRules()
-      );
-      this.scriptHandlerMap.put(userOnlyScript, scriptHandler);
+      try {
+        ScriptHandler scriptHandler = WebViewCompat.addDocumentStartJavaScript(
+                webView,
+                wrapSourceCodeInContentWorld(userOnlyScript.getContentWorld(), source),
+                userOnlyScript.getAllowedOriginRules()
+        );
+        this.scriptHandlerMap.put(userOnlyScript, scriptHandler);
+      } catch (RuntimeException e) {
+        // Chromium throws "Must be started before we block!" when this runs before the browser
+        // process finished starting (first webview of a cold process). Letting it propagate aborts
+        // the whole platform-view create, which is what leaves the webview blank and
+        // onWebViewCreated unfired (#2843): skip instead. The script is not stored in
+        // scriptHandlerMap, so a later re-add retries the native registration.
+        Log.e(LOG_TAG, "addDocumentStartJavaScript failed for " + userOnlyScript.getGroupName()
+                + " (browser process not started yet?): " + e);
+      }
     }
     return this.userOnlyScripts.get(userOnlyScript.getInjectionTime()).add(userOnlyScript);
   }
@@ -307,12 +318,20 @@ public class UserContentController implements Disposable {
         @Override
         public void run() {
           if (webView != null) {
-            ScriptHandler scriptHandler = WebViewCompat.addDocumentStartJavaScript(
-                    webView,
-                    finalSource,
-                    pluginScript.getAllowedOriginRules()
-            );
-            scriptHandlerMap.put(pluginScript, scriptHandler);
+            try {
+              ScriptHandler scriptHandler = WebViewCompat.addDocumentStartJavaScript(
+                      webView,
+                      finalSource,
+                      pluginScript.getAllowedOriginRules()
+              );
+              scriptHandlerMap.put(pluginScript, scriptHandler);
+            } catch (RuntimeException e) {
+              // "Must be started before we block!" before browser startup completes. An uncaught
+              // throw here would kill the main thread (we are inside a posted runnable): log and
+              // skip instead; a later re-add retries the registration.
+              Log.e(LOG_TAG, "addDocumentStartJavaScript failed for plugin script "
+                      + pluginScript.getGroupName() + ": " + e);
+            }
           }
         }
       });

--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/types/UserContentController.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/types/UserContentController.java
@@ -279,7 +279,7 @@ public class UserContentController implements Disposable {
     return pluginScriptsRequired;
   }
 
-  public boolean addPluginScript(PluginScript pluginScript) {
+  public boolean addPluginScript(final PluginScript pluginScript) {
     ContentWorld contentWorld = pluginScript.getContentWorld();
     if (contentWorld != null) {
       contentWorlds.add(contentWorld);
@@ -291,13 +291,31 @@ public class UserContentController implements Disposable {
         source = "if (document.readyState === 'complete') { " + source + "} else { window.addEventListener('load', function() { " + source + " }); }";
       }
       source = wrapSourceCodeAddChecks(source, pluginScript);
+      final String finalSource = wrapSourceCodeInContentWorld(pluginScript.getContentWorld(), source);
 
-      ScriptHandler scriptHandler = WebViewCompat.addDocumentStartJavaScript(
-              webView,
-              wrapSourceCodeInContentWorld(pluginScript.getContentWorld(), source),
-              pluginScript.getAllowedOriginRules()
-      );
-      this.scriptHandlerMap.put(pluginScript, scriptHandler);
+      // Defer WebViewCompat.addDocumentStartJavaScript to the next UI-thread
+      // message. Its binder IPC to the Chromium renderer process must not run
+      // while FlutterWebView is still synchronously building the platform view.
+      // InAppWebView.prepareAndAddUserScripts() issues 5 to 9 of these
+      // registrations synchronously when the JS bridge is enabled (PromisePolyfill,
+      // JS Bridge, Print, OnWindowBlur, OnWindowFocus, plus up to four more
+      // depending on settings); running them inline was observed to leave
+      // onWebViewCreated never fired on ~50% of release-build cold starts on real
+      // Android devices, with the failure toggling deterministically across kill-
+      // relaunch cycles. Debug builds were not affected.
+      webView.post(new Runnable() {
+        @Override
+        public void run() {
+          if (webView != null) {
+            ScriptHandler scriptHandler = WebViewCompat.addDocumentStartJavaScript(
+                    webView,
+                    finalSource,
+                    pluginScript.getAllowedOriginRules()
+            );
+            scriptHandlerMap.put(pluginScript, scriptHandler);
+          }
+        }
+      });
     }
     return this.pluginScripts.get(pluginScript.getInjectionTime()).add(pluginScript);
   }

--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/in_app_webview/FlutterWebView.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/in_app_webview/FlutterWebView.java
@@ -94,7 +94,7 @@ public class FlutterWebView implements PlatformWebView {
     }
 
     Integer windowId = (Integer) params.get("windowId");
-    Map<String, Object> initialUrlRequest = (Map<String, Object>) params.get("initialUrlRequest");
+    final Map<String, Object> initialUrlRequest = (Map<String, Object>) params.get("initialUrlRequest");
     final String initialFile = (String) params.get("initialFile");
     final Map<String, String> initialData = (Map<String, String>) params.get("initialData");
 
@@ -124,27 +124,42 @@ public class FlutterWebView implements PlatformWebView {
         }
       }
     } else {
-      if (initialFile != null) {
-        try {
-          webView.loadFile(initialFile);
-        } catch (IOException e) {
-          Log.e(LOG_TAG, initialFile + " asset file cannot be found!", e);
+      // Defer the initial load to the next UI-thread message so the bridge
+      // native registrations posted from InAppWebView.prepare()
+      // (addJavascriptInterface and addDocumentStartJavaScript) run before the
+      // renderer receives the load IPC. Without this, the load IPC fires
+      // synchronously here, races ahead of the deferred bridge registrations,
+      // and pages cached or served fast enough can execute @document-start
+      // scripts before window.flutter_inappwebview is defined.
+      webView.post(new Runnable() {
+        @Override
+        public void run() {
+          if (webView == null) {
+            return;
+          }
+          if (initialFile != null) {
+            try {
+              webView.loadFile(initialFile);
+            } catch (IOException e) {
+              Log.e(LOG_TAG, initialFile + " asset file cannot be found!", e);
+            }
+          }
+          else if (initialData != null) {
+            String data = initialData.get("data");
+            String mimeType = initialData.get("mimeType");
+            String encoding = initialData.get("encoding");
+            String baseUrl = initialData.get("baseUrl");
+            String historyUrl = initialData.get("historyUrl");
+            webView.loadDataWithBaseURL(baseUrl, data, mimeType, encoding, historyUrl);
+          }
+          else if (initialUrlRequest != null) {
+            URLRequest urlRequest = URLRequest.fromMap(initialUrlRequest);
+            if (urlRequest != null) {
+              webView.loadUrl(urlRequest);
+            }
+          }
         }
-      }
-      else if (initialData != null) {
-        String data = initialData.get("data");
-        String mimeType = initialData.get("mimeType");
-        String encoding = initialData.get("encoding");
-        String baseUrl = initialData.get("baseUrl");
-        String historyUrl = initialData.get("historyUrl");
-        webView.loadDataWithBaseURL(baseUrl, data, mimeType, encoding, historyUrl);
-      }
-      else if (initialUrlRequest != null) {
-        URLRequest urlRequest = URLRequest.fromMap(initialUrlRequest);
-        if (urlRequest != null) {
-          webView.loadUrl(urlRequest);
-        }
-      }
+      });
     }
   }
 

--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/in_app_webview/InAppWebView.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/in_app_webview/InAppWebView.java
@@ -272,7 +272,22 @@ final public class InAppWebView extends InputAwareWebView implements InAppWebVie
 
     if (javaScriptBridgeEnabled) {
       javaScriptBridgeInterface = new JavaScriptBridgeInterface(this, expectedBridgeSecret);
-      addJavascriptInterface(javaScriptBridgeInterface, JavaScriptBridgeJS.get_JAVASCRIPT_BRIDGE_NAME());
+      // Defer addJavascriptInterface to the next UI-thread message. Its binder
+      // IPC to the Chromium renderer process must not run while FlutterWebView
+      // is still synchronously building the platform view: doing so was observed
+      // to leave onWebViewCreated never fired on ~50% of release-build cold
+      // starts on real Android devices, with the failure toggling deterministically
+      // across kill-relaunch cycles. Debug builds were not affected.
+      // See UserContentController.addPluginScript for the equivalent defer applied
+      // to addDocumentStartJavaScript.
+      post(new Runnable() {
+        @Override
+        public void run() {
+          if (javaScriptBridgeInterface != null) {
+            addJavascriptInterface(javaScriptBridgeInterface, JavaScriptBridgeJS.get_JAVASCRIPT_BRIDGE_NAME());
+          }
+        }
+      });
     }
 
     inAppWebViewChromeClient = new InAppWebViewChromeClient(plugin, this, inAppBrowserDelegate);


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #2843 

<!-- Replace NNNN with the issue number you just created -->

## Testing and Review Notes

### Problem

See linked issue for full repro and analysis. Short version: on release/AOT Android builds, `addJavascriptInterface()` and the 5 to 9 `WebViewCompat.addDocumentStartJavaScript()` calls run synchronously inside `InAppWebView.prepare()` during the platform-view attach. This race left `onWebViewCreated` never fired on ~50% of cold starts on real Android devices (alternating across kill-relaunch cycles), only on release builds, with `javaScriptBridgeEnabled` default to true (the default since 6.2.0-beta.1).

### Fix

This PR contains two commits applied in sequence.

**Commit 1: defer the bridge native registrations off the platform-view attach.**

Wrap `addJavascriptInterface` (`InAppWebView.java:275`) and `WebViewCompat.addDocumentStartJavaScript` (called from `UserContentController.addPluginScript`) in `View.post(Runnable)` so they run in the next UI-thread message, after the platform view has been attached. This alone makes `onWebViewCreated` fire reliably on every cold start.

**Commit 2: defer the initial load too, so the bridge is guaranteed registered first.**

After commit 1 the bridge registrations are posted to the UI-thread queue, but `FlutterWebViewFactory.create()` then calls `FlutterWebView.makeInitialLoad()` synchronously, which issues the load IPC (`loadFile` / `loadDataWithBaseURL` / `loadUrl`) to the Chromium renderer process immediately. The load IPC therefore raced ahead of the deferred bridge registrations, and pages served fast (cached content, or sleeping-tab wake-ups on apps that lazy-construct tabs) could execute `@document-start` scripts before `window.flutter_inappwebview` was defined.

Wrap the three initial-load branches inside `makeInitialLoad` in `webView.post(Runnable)` so the load IPC enters the same UI-thread queue FIFO behind the bridge registrations.

Three files modified:

- `flutter_inappwebview_android/.../webview/in_app_webview/InAppWebView.java`: defer `addJavascriptInterface`.
- `flutter_inappwebview_android/.../types/UserContentController.java`: defer `WebViewCompat.addDocumentStartJavaScript` inside `addPluginScript`.
- `flutter_inappwebview_android/.../webview/in_app_webview/FlutterWebView.java`: defer the initial load (`loadFile` / `loadDataWithBaseURL` / `loadUrl`) inside `makeInitialLoad` so it queues after the bridge registrations.

The `windowId != null` branch of `makeInitialLoad` already used `webView.post(...)` for `prepareAndAddUserScripts` (see `FlutterWebView.java:115-122`), so the pattern is precedented in this codebase.

### How to test

1. Check out this branch.
2. `cd flutter_inappwebview/example && flutter build apk --release`.
3. Install on a real Android device.
4. Use the minimal repro app in the linked issue (or the example app itself).
5. Cold-launch 10 times in a row: `onWebViewCreated` should fire on every launch.
6. Optionally: inject a userscript at `@run-at document-start` that reads `window.flutter_inappwebview` on a page served from cache. With the patch the bridge should always be available; without it, fast/cached pages may see `undefined`.

Without this patch (against current `master`): step 5 shows the failure on ~50% of launches alternating, and step 6 shows the bridge undefined on a portion of fast loads.

### Side-effect notes

- `WebViewCompat.addDocumentStartJavaScript` now happens one UI-thread message later. The `scriptHandler` previously stored synchronously in `scriptHandlerMap` is now stored inside the runnable. Any code that calls `removePluginScript()` between `addPluginScript()` and the runnable dispatch (a few microseconds in practice) would not find the handler in the map. I could not find a caller in the codebase that does this in practice. Happy to add a queueing mechanism if you think it's a concern.
- The initial load is now also posted one UI-thread message later. Visible effect on cold start is sub-millisecond on the device used.
- `useHybridComposition` and the rest of the platform-view attach code is untouched, only the bridge and the initial load are reordered into the UI-thread queue.
- I considered `onAttachedToWindow` instead of `post()`, but `post()` runs deterministically once the current message returns, whereas `onAttachedToWindow` fires when the view is attached to a window, which can be later and for headless WebViews it may never fire at all.

### Verified

- 10/10 release cold starts now fire `onWebViewCreated` on the device used for repro.
- Userscripts at both `@run-at document-start` and `@run-at document-end` execute correctly with the patch applied.
- `window.flutter_inappwebview.callHandler('isTornPDA')` returns expected payload from JS via a userscript test, regardless of injection time, including on fast cached pages and on sleeping-tab wake-ups in an app that lazy-constructs tabs.
- Existing example app builds and runs in both debug and release.

## Screenshots or Videos

Not applicable, the bug has no visible UI symptom beyond a blank webview.

## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable): N/A