### PR TITLE
[iOS] Serialize console arguments so objects and Errors keep their data

### DIFF
--- a/flutter_inappwebview_ios/ios/flutter_inappwebview_ios/Sources/flutter_inappwebview_ios/PluginScriptsJS/ConsoleLogJS.swift
+++ b/flutter_inappwebview_ios/ios/flutter_inappwebview_ios/Sources/flutter_inappwebview_ios/PluginScriptsJS/ConsoleLogJS.swift
@@ -32,9 +32,29 @@ public class ConsoleLogJS {
         
             function _callHandler(logLevel, args) {
                 var message = '';
+                function _stringify(v) {
+                    try {
+                        if (v === null || typeof v !== 'object') return String(v);
+                        if (v instanceof Error) return v.name + ': ' + v.message + (v.stack ? '\\n' + v.stack : '');
+                        // Only stringify plain objects/arrays; leave DOM nodes, host objects and
+                        // proxies to String() so we don't trip their getters (e.g. .outerHTML).
+                        var proto = Object.getPrototypeOf(v);
+                        if (Array.isArray(v) || proto === Object.prototype || proto === null) {
+                            var s = JSON.stringify(v);
+                            if (typeof s === 'string') return s.length > 2000 ? s.slice(0, 2000) + '...(truncated)' : s;
+                        }
+                    } catch(_) {}
+                    var str;
+                    try { str = String(v); } catch(_) { return '[object]'; }
+                    // Upgrade the generic [object Object] to the constructor name.
+                    if (str === '[object Object]') {
+                        try { var cn = v.constructor && v.constructor.name; if (cn) return '[object ' + cn + ']'; } catch(_) {}
+                    }
+                    return str;
+                }
                 for (var i in args) {
                     try {
-                        message += message === '' ? args[i] : ' ' + args[i];
+                        message += (message === '' ? '' : ' ') + _stringify(args[i]);
                     } catch(_) {}
                 }
                 try {


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #2850

## Testing and Review Notes

### Problem

On iOS, `ConsoleLogJS.CONSOLE_LOG_JS_SOURCE()` builds the message sent to
`onConsoleMessage` by string-concatenating each argument
(`message += message === '' ? args[i] : ' ' + args[i]`). Non-string arguments are
coerced: objects become `[object Object]` and `Error` objects lose their message and
stack. Logging objects/errors from a page is therefore unreadable on iOS. Android is
unaffected because it forwards the native `ConsoleMessage.message()`.

### Fix

Add a small `_stringify` helper inside `_callHandler` and use it per argument:
- `Error` -> `name + ': ' + message` plus the stack (WebKit's `error.stack` does not
  prepend the `name: message` line, unlike V8, so it is prepended explicitly).
- non-null `object` -> `JSON.stringify`, capped at 2000 chars to avoid flooding the
  bridge (falls back to `String(v)` if stringify throws, e.g. circular references).
- everything else -> `String(v)`, identical to the previous behavior.

Primitives are unchanged, so existing string/number logs are byte-for-byte the same.
The whole helper stays inside the existing `try/catch`, so a failure can never break
logging. Only `flutter_inappwebview_ios` is touched.

### How to test

1. Check out this branch and run the example app on an iOS device/simulator.
2. From a loaded page (or an injected script) run:

```js
console.log("object:", { foo: 1, bar: [1, 2, 3], nested: { a: true } });
console.error("error:", new Error("boom"));
try { null.x; } catch (e) { console.error("caught:", e); }
console.log("primitives:", "hello", 42, true, null, undefined);
```

3. Observe the strings delivered to `onConsoleMessage`.

With the patch:
- `object:` -> `{"foo":1,"bar":[1,2,3],"nested":{"a":true}}`
- `error:` -> `Error: boom` followed by the stack
- `caught:` -> `TypeError: null is not an object (evaluating 'null.x')` followed by the stack
- `primitives:` -> `hello 42 true null undefined` (unchanged)

Without the patch (current master): `object:` is `[object Object]` and the Errors lose
their message and stack.

### Side-effect notes

- `JSON.stringify` only runs for arguments whose `typeof` is `object`; primitives keep
  the previous `String()` path, so the common case (string logs) is unchanged.
- Output is capped at 2000 chars to bound the bridge payload.
- This makes iOS console output more detailed than before; the source comment about
  matching Android is now better served, since native Android already serializes objects.

### Verified

- Objects, arrays, Errors (thrown and constructed), primitives, circular references and
  very large objects all log as expected on iOS; circular refs fall back safely without
  throwing; large objects truncate with `...(truncated)`.
- Primitive logging output is unchanged.

## Screenshots or Videos

Not applicable.

## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable): N/A
