### PR TITLE
[flutter_inappwebview_ios] Fix requestFocus() so document focus works inside Flutter platform views

### DIFF
--- a/flutter_inappwebview_ios/CHANGELOG.md
+++ b/flutter_inappwebview_ios/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.2.0-beta.3
 
+- Fixed `requestFocus` not focusing the WebView on iOS when embedded as a Flutter platform view [#1974](https://github.com/pichillilorenzo/flutter_inappwebview/issues/1974)
 - Updated flutter_inappwebview_platform_interface version to ^1.4.0-beta.3
 - Implemented `saveState`, `restoreState` InAppWebViewController methods
 - Implemented `PlatformProxyController` class

--- a/flutter_inappwebview_ios/ios/flutter_inappwebview_ios/Sources/flutter_inappwebview_ios/InAppWebView/InAppWebView.swift
+++ b/flutter_inappwebview_ios/ios/flutter_inappwebview_ios/Sources/flutter_inappwebview_ios/InAppWebView/InAppWebView.swift
@@ -3377,7 +3377,18 @@ if(window.\(JavaScriptBridgeJS.get_JAVASCRIPT_BRIDGE_NAME())[\(_callHandlerID)] 
     }
 
     public func requestFocus() -> Bool {
-        return self.scrollView.subviews.first?.becomeFirstResponder() ?? false
+        // becomeFirstResponder() on scrollView.subviews.first often returns false inside a
+        // Flutter platform view. Search the subtree for the focusable content view
+        // (WKContentView) and make that the first responder; fall back to the web view itself.
+        var stack: [UIView] = subviews
+        while !stack.isEmpty {
+            let v = stack.removeFirst()
+            if v.canBecomeFirstResponder, v.becomeFirstResponder() {
+                return true
+            }
+            stack.append(contentsOf: v.subviews)
+        }
+        return becomeFirstResponder()
     }
     
     public func getCertificate() -> SslCertificate? {


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #1974

## Testing and Review Notes

The iOS `InAppWebView.requestFocus()` did:

```swift
return self.scrollView.subviews.first?.becomeFirstResponder() ?? false
```

`scrollView.subviews.first` is not reliably the focusable content view, so `becomeFirstResponder()` returns `false` when the `WKWebView` is embedded as a Flutter platform view. As a result `document.hasFocus()` stays `false` and the window `focus`/`blur` events never fire until the user physically taps the page.

This PR walks the web view's subtree and makes the first view that reports `canBecomeFirstResponder` (the `WKContentView`) the first responder, falling back to the web view itself:

```swift
public func requestFocus() -> Bool {
    var stack: [UIView] = subviews
    while !stack.isEmpty {
        let v = stack.removeFirst()
        if v.canBecomeFirstResponder, v.becomeFirstResponder() {
            return true
        }
        stack.append(contentsOf: v.subviews)
    }
    return becomeFirstResponder()
}
```

How to verify:
1. Embed an `InAppWebView` on iOS (e.g. inside an `IndexedStack` of tabs).
2. Call `controller.requestFocus()` after the web view is shown (e.g. on tab switch), or switch away and back.
3. Before: `document.hasFocus()` stays `false`, no `focus` event until you tap. After: `requestFocus()` returns `true`, `document.hasFocus()` is `true`, and the window `focus` event fires with no tap.

Notes: `clearFocus()` has the symmetric `scrollView.subviews.first` pattern and is left unchanged to keep this PR focused. Android is unaffected (uses `WebView.requestFocus`). No public API change (the `requestFocus` method already exists across the federated layers); only the iOS native implementation changes, so no codegen / platform_interface changes are required.

## Screenshots or Videos

N/A

## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable): N/A, native focus fix
