### PR TITLE
iOS: restore scrollView.contentInset on keyboardWillHide (#1947 regression)

### DIFF
--- a/flutter_inappwebview_ios/ios/flutter_inappwebview_ios/Sources/flutter_inappwebview_ios/InAppWebView/InAppWebView.swift
+++ b/flutter_inappwebview_ios/ios/flutter_inappwebview_ios/Sources/flutter_inappwebview_ios/InAppWebView/InAppWebView.swift
@@ -143,6 +143,21 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
     }
     @objc func keyboardWillHide(notification: NSNotification) {
         _scrollViewContentInsetAdjusted = false
+        // keyboardWillShow set a negative contentInset to absorb the keyboard; restore
+        // the frame-setter compensation here or it stays negative and the page bounces
+        // before the bottom (iOS 17.2+). Async so the keyboard is gone and
+        // adjustedContentInset is accurate.
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.scrollView.contentInset = .zero
+            if #available(iOS 11, *) {
+                if self.scrollView.adjustedContentInset != .zero {
+                    let insetToAdjust = self.scrollView.adjustedContentInset
+                    self.scrollView.contentInset = UIEdgeInsets(top: -insetToAdjust.top, left: -insetToAdjust.left,
+                                                                bottom: -insetToAdjust.bottom, right: -insetToAdjust.right)
+                }
+            }
+        }
     }
     
     required public init(coder aDecoder: NSCoder) {


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #2859

Connected to #1947

## Summary

On iOS 17.2+, after the on-screen keyboard is shown and dismissed once, a WKWebView can no longer be scrolled all the way to the bottom: it rubber-bands back before the end.

Regression introduced by the #1947 fix (commit `e74cde0`, "updated fix for #1947 when resizeToAvoidBottomInset is false"), which added keyboard observers gated to iOS 17.2+. `keyboardWillShow` sets a negative `scrollView.contentInset` to absorb the keyboard space, but `keyboardWillHide` only resets the guard flag and never restores the inset, so the negative `contentInset.bottom` stays after the keyboard hides:

```swift
// before (buggy)
@objc func keyboardWillHide(notification: NSNotification) {
    _scrollViewContentInsetAdjusted = false
}
```

Because the inset lives on the (per-tab) scrollView, it also persists across in-app navigations until a real frame change (e.g. device rotation) resets it via the `frame` setter — which is why rotating to landscape "fixes" it, and why a page with no input of its own can still be stuck if the keyboard was opened earlier on another page.

## Fix

`keyboardWillHide` now restores the same compensation the `frame` setter applies (reset to `.zero`, then negate `adjustedContentInset`), dispatched async so the keyboard is fully gone and `adjustedContentInset` is accurate:

```swift
@objc func keyboardWillHide(notification: NSNotification) {
    _scrollViewContentInsetAdjusted = false
    DispatchQueue.main.async { [weak self] in
        guard let self = self else { return }
        self.scrollView.contentInset = .zero
        if #available(iOS 11, *) {
            if self.scrollView.adjustedContentInset != .zero {
                let insetToAdjust = self.scrollView.adjustedContentInset
                self.scrollView.contentInset = UIEdgeInsets(top: -insetToAdjust.top, left: -insetToAdjust.left,
                                                            bottom: -insetToAdjust.bottom, right: -insetToAdjust.right)
            }
        }
    }
}
```

## Testing and Review Notes

Verified on the **iOS Simulator running iOS 26.2** (the keyboard observers are gated behind `if #available(iOS 17.2, *)`, so the issue needs iOS 17.2+), with a minimal standalone app built against the plugin **before** and **after** this change.

The trigger is a host `Scaffold` with **`resizeToAvoidBottomInset: false`**: that routes the keyboard inset to the WKWebView scrollView, so `keyboardWillShow` takes the negative-`contentInset` branch. With `resizeToAvoidBottomInset: true` Flutter absorbs the keyboard and the bug does not appear.

Minimal repro used:

```dart
import 'package:flutter/material.dart';
import 'package:flutter_inappwebview/flutter_inappwebview.dart';

void main() => runApp(const MaterialApp(home: ReproPage()));

class ReproPage extends StatelessWidget {
  const ReproPage({super.key});
  @override
  Widget build(BuildContext context) {
    return Scaffold(
      // Key trigger: routes the keyboard inset to the WKWebView scrollView.
      resizeToAvoidBottomInset: false,
      body: SafeArea(
        child: InAppWebView(
          initialData: InAppWebViewInitialData(data: _html),
        ),
      ),
    );
  }
}

const String _html = '''
<!DOCTYPE html>
<html>
<head><meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"></head>
<body style="margin:0; font-family:-apple-system,sans-serif">
  <div style="position:sticky; top:0; padding:12px; background:#ffd; border-bottom:1px solid #ccc">
    <div style="font-size:13px; margin-bottom:6px">STEP 1: tap this field so the keyboard shows, then dismiss it</div>
    <input type="text" placeholder="tap me" style="font-size:16px; width:92%; padding:8px">
  </div>
  <div style="height:2600px; background:linear-gradient(#ffffff,#0091ff)"></div>
  <div style="padding:28px; font-size:20px; color:#fff; background:#0a7d2c">
    STEP 2: scroll all the way down. If you CANNOT reach this green block (it bounces
    back before the end), the bug is present. Rotate to landscape and back to clear it.
  </div>
</body>
</html>
''';
```

Steps:
1. Run on iOS 17.2+ (verified on the iOS Simulator, iOS 26.2).
2. Tap the input so the keyboard appears, then dismiss it.
3. Try to scroll to the bottom (the green block).

Results:
- **Before:** step 3 bounces back before reaching the green block; rotating to landscape and back clears it; setting `resizeToAvoidBottomInset: true` also avoids it (confirms the trigger).
- **After:** step 3 scrolls cleanly to the green block, with `resizeToAvoidBottomInset: false`.

## Screenshots or Videos

<!-- Optional: a before/after screen recording on iOS 17.2+ can be attached here. -->

## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes (with a minimal repro) in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable) — N/A (native scroll fix)
