### PR TITLE
Android: add InAppWebViewController.setBackgroundColor to override the WebView background

### DIFF
--- a/flutter_inappwebview/lib/src/in_app_webview/in_app_webview_controller.dart
+++ b/flutter_inappwebview/lib/src/in_app_webview/in_app_webview_controller.dart
@@ -154,6 +154,10 @@ class InAppWebViewController {
   ///{@macro flutter_inappwebview_platform_interface.PlatformInAppWebViewController.reload.supported_platforms}
   Future<void> reload() => platform.reload();
 
+  ///Android-only: sets the native WebView container background color (ARGB int), to avoid the white flash
+  ///when transparentBackground is disabled. See [PlatformInAppWebViewController.setBackgroundColor].
+  Future<void> setBackgroundColor({required int color}) => platform.setBackgroundColor(color: color);
+
   ///{@macro flutter_inappwebview_platform_interface.PlatformInAppWebViewController.goBack}
   ///
   ///{@macro flutter_inappwebview_platform_interface.PlatformInAppWebViewController.goBack.supported_platforms}

--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/WebViewChannelDelegate.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/WebViewChannelDelegate.java
@@ -96,6 +96,16 @@ public class WebViewChannelDelegate extends ChannelDelegateImpl {
       case getProgress:
         result.success((webView != null) ? webView.getProgress() : null);
         break;
+      case setBackgroundColor:
+        if (webView != null) {
+          // Flutter encodes an ARGB int (alpha 0xFF makes it > 2^31) as a Long, so read it as a Number
+          Number color = (Number) call.argument("color");
+          if (color != null) {
+            webView.setBackgroundColor(color.intValue());
+          }
+        }
+        result.success(true);
+        break;
       case loadUrl:
         if (webView != null) {
           Map<String, Object> urlRequest = (Map<String, Object>) call.argument("urlRequest");

--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/WebViewChannelDelegateMethods.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/WebViewChannelDelegateMethods.java
@@ -88,4 +88,5 @@ public enum WebViewChannelDelegateMethods {
   showInputMethod,
   saveState,
   restoreState,
+  setBackgroundColor,
 }

--- a/flutter_inappwebview_android/lib/src/in_app_webview/in_app_webview_controller.dart
+++ b/flutter_inappwebview_android/lib/src/in_app_webview/in_app_webview_controller.dart
@@ -2163,6 +2163,13 @@ class AndroidInAppWebViewController extends PlatformInAppWebViewController
   }
 
   @override
+  Future<void> setBackgroundColor({required int color}) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('color', () => color);
+    await channel?.invokeMethod('setBackgroundColor', args);
+  }
+
+  @override
   Future<void> goBack() async {
     Map<String, dynamic> args = <String, dynamic>{};
     await channel?.invokeMethod('goBack', args);

--- a/flutter_inappwebview_platform_interface/lib/src/in_app_webview/platform_inappwebview_controller.dart
+++ b/flutter_inappwebview_platform_interface/lib/src/in_app_webview/platform_inappwebview_controller.dart
@@ -723,6 +723,14 @@ abstract class PlatformInAppWebViewController extends PlatformInterface
     );
   }
 
+  ///Android-only: sets the native WebView container background color (ARGB int). Useful to override the
+  ///opaque white background the platform paints when transparentBackground is disabled.
+  Future<void> setBackgroundColor({required int color}) {
+    throw UnimplementedError(
+      'setBackgroundColor is not implemented on the current platform',
+    );
+  }
+
   ///{@template flutter_inappwebview_platform_interface.PlatformInAppWebViewController.goBack}
   ///Goes back in the history of the WebView.
   ///{@endtemplate}


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #2863

## Summary

Adds `InAppWebViewController.setBackgroundColor`, an Android only method that sets the native WebView container background color (ARGB int). This gives apps a way to override the hardcoded white background used when `transparentBackground` is false, so dark themed apps do not flash white during the platform-view first paint or on tab switches.

Non Android platforms inherit the default implementation, which throws `UnimplementedError`, so behavior there is unchanged.

Implementation:
- `PlatformInAppWebViewController.setBackgroundColor` (default throws `UnimplementedError`).
- Android implementation sends the ARGB int over the method channel.
- The main `InAppWebViewController` forwards to the platform controller.
- The Android channel handler calls `View.setBackgroundColor(int)`.

## Testing and Review Notes

Tested on Android (real device and emulator, dark app theme).

Repro before the change:
1. Open several webviews or tabs quickly.
2. Switch back to one of them.
3. Observe a short white flash before the page repaints (the native surface is painted `#FFFFFF`).

After the change, the host app calls `setBackgroundColor` with its theme background color once the first load starts, and the same step shows the theme color instead of white, with no white flash.

Note: the color is passed as an ARGB int. Flutter encodes an ARGB value whose alpha is `0xFF` as a Long over the method channel, so the Android handler reads the argument as a `Number` and calls `intValue()`.

Note for maintainers: the new method uses a plain string in its `UnimplementedError`. If you prefer the fully code-generated form, I am happy to add the `@SupportedPlatforms` annotation and regenerate so the value is added to `PlatformInAppWebViewControllerMethod`.

## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable)
