### PR TITLE
Windows: VS 2026 / MSVC 14.5x build fixes

### DIFF
--- a/flutter_inappwebview_windows/windows/CMakeLists.txt
+++ b/flutter_inappwebview_windows/windows/CMakeLists.txt
@@ -4,8 +4,8 @@
 # customers of the plugin.
 cmake_minimum_required(VERSION 3.14)
 
-set(WIL_VERSION "1.0.250325.1")
-set(WEBVIEW_VERSION "1.0.3650.58")
+set(WIL_VERSION "1.0.260126.7")
+set(WEBVIEW_VERSION "1.0.4078.44")
 set(NLOHMANN_JSON_VERSION "3.12.0")
 set(CPP_WINRT_VERSION "2.0.250303.1")
 
@@ -296,6 +296,8 @@ function(FLUTTER_INAPPWEBVIEW_WINDOWS_APPLY_STANDARD_SETTINGS TARGET)
   target_compile_options(${TARGET} PRIVATE /bigobj)
   target_compile_definitions(${TARGET} PRIVATE "_HAS_EXCEPTIONS=0")
   target_compile_definitions(${TARGET} PRIVATE "$<$<CONFIG:Debug>:_DEBUG>")
+  target_compile_definitions(${TARGET} PRIVATE "_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS")
+  target_compile_options(${TARGET} PRIVATE /FS)
 endfunction()
 flutter_inappwebview_windows_apply_standard_settings(${PLUGIN_NAME})
 


### PR DESCRIPTION
Three fixes to build flutter_inappwebview_windows with Visual Studio 2026 (MSVC 14.5x) and Windows SDK 10.0.26100, all scoped to the plugin target in FLUTTER_INAPPWEBVIEW_WINDOWS_APPLY_STANDARD_SETTINGS and backward-compatible with VS 2022:

- Bump Microsoft.Web.WebView2 (1.0.4078.44) and Microsoft.Windows.ImplementationLibrary / WIL (1.0.260126.7) nuget packages so their headers compile under the newer toolchain + SDK.
- Add /FS: the plugin's ~95 sources build under /MP (parallel cl.exe) all writing the same vc145.pdb; without /FS that races and fails with C1041. /FS serializes PDB writes.
- Define _SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS: the plugin builds /std:c++17, so its co_await code pulls in <experimental/coroutine>, whose deprecation MSVC 14.5x promoted (STL1011) to a hard error C2338. This is Microsoft's documented escape hatch until the plugin migrates to C++20 <coroutine>.

## Connection with issue(s)

Resolve issue [#2839](https://github.com/pichillilorenzo/flutter_inappwebview/issues/2839)

## Testing and Review Notes

**Environment the fix was validated on**
- Visual Studio 2026 (MSVC 14.51.36231, toolset v18), Windows SDK 10.0.26100, Windows 11 x64.
- Built via `flutter build windows` (CMake + Ninja), both incremental and full clean-from-empty. The plugin compiles and links, `flutter_inappwebview_windows_plugin.dll` is produced, and the WebView renders and navigates at runtime.

**Reproducing the failures without this patch** (VS 2026 / MSVC 14.5x)
- Old WebView2/WIL nuget versions: header compile errors under the newer toolchain + SDK 10.0.26100.
- Without `/FS`: intermittent `fatal error C1041: cannot open program database ...vc145.pdb` — the ~95 sources build under `/MP` and race the shared PDB. Reproducible under parallel builds; disappears with `-j1`.
- Without the coroutine define: `error C2338 (STL1011)` from `<experimental/coroutine>` — MSVC 14.5x promoted the deprecation to a hard error for `/std:c++17` code using `co_await`.

**Confirming the fix**
1. On a VS 2026 / SDK 10.0.26100 machine, build any Flutter app depending on this package (or the example) for Windows: `flutter build windows`.
2. Expect a clean compile+link with no C1041, no C2338, and no WebView2/WIL header errors.
3. Run the app and confirm the WebView loads a URL, executes JS, and navigates — i.e. the nuget bump didn't change runtime behavior.

**Backward compatibility with VS 2022 (MSVC 14.3x)** — all three changes are scoped to the plugin target inside `FLUTTER_INAPPWEBVIEW_WINDOWS_APPLY_STANDARD_SETTINGS`, and none regress the older toolchain:
- `/FS` has existed since VS 2013 and only serializes PDB writes; it's a no-op when there's no PDB contention.
- `_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS` is Microsoft's documented escape hatch; on 14.3x the deprecation is a warning (or the header isn't reached), so the define is harmless.
- The WebView2/WIL nuget versions still compile under VS 2022 (they're forward-only header bumps, no API removals used by the plugin).

**Reviewer note:** the cleanest long-term fix for the coroutine define is migrating the plugin from `/std:c++17` + `<experimental/coroutine>` to `/std:c++20` + `<coroutine>`; the define is intended as a stopgap until then.

---
*Investigated and verified with Claude Opus 4.8.*