### PR TITLE
[flutter_inappwebview_ios] Fix callAsyncJavaScript crashes before iOS 18

### DIFF
--- a/flutter_inappwebview/example/integration_test/in_app_webview/javascript_code_evaluation.dart
+++ b/flutter_inappwebview/example/integration_test/in_app_webview/javascript_code_evaluation.dart
@@ -1,5 +1,17 @@
 part of 'main.dart';
 
+bool _isIOSVersion(int major, int minor) {
+  if (!Platform.isIOS) {
+    return false;
+  }
+  final match = RegExp(
+    r'(\d+)\.(\d+)',
+  ).firstMatch(Platform.operatingSystemVersion);
+  return match != null &&
+      int.parse(match.group(1)!) == major &&
+      int.parse(match.group(2)!) == minor;
+}
+
 void javascriptCodeEvaluation() {
   final shouldSkip = !InAppWebViewController.isMethodSupported(
     PlatformInAppWebViewControllerMethod.evaluateJavascript,
@@ -111,6 +123,9 @@ void javascriptCodeEvaluation() {
           child: InAppWebView(
             key: GlobalKey(),
             initialUrlRequest: URLRequest(url: TEST_URL_ABOUT_BLANK),
+            initialSettings: Platform.isIOS
+                ? InAppWebViewSettings(javaScriptBridgeEnabled: false)
+                : null,
             onWebViewCreated: (controller) {
               controllerCompleter.complete(controller);
             },
@@ -149,6 +164,7 @@ void javascriptCodeEvaluation() {
       result = await controller.callAsyncJavaScript(
         functionBody: functionBody,
         arguments: {'x': -49, 'y': 'error message'},
+        contentWorld: ContentWorld.PAGE,
       );
       expect(result, isNotNull);
       expect(result!.value, isNull);
@@ -185,11 +201,25 @@ void javascriptCodeEvaluation() {
           await controllerCompleter.future;
       await pageLoaded.future;
 
-      await controller.callAsyncJavaScript(
+      var result = await controller.callAsyncJavaScript(
         functionBody: "window.foo = 49;",
         contentWorld: ContentWorld.world(name: "custom-world"),
       );
-      var result = await controller.callAsyncJavaScript(
+      if (_isIOSVersion(16, 0)) {
+        expect(result, isNotNull);
+        expect(result!.value, isNull);
+        expect(
+          result.error,
+          "Custom content worlds are not supported by callAsyncJavaScript "
+          "on iOS 16.0.x",
+        );
+        return;
+      }
+
+      expect(result, isNotNull);
+      expect(result!.error, isNull);
+
+      result = await controller.callAsyncJavaScript(
         functionBody: "return window.foo;",
       );
       expect(result, isNotNull);

--- a/flutter_inappwebview_ios/ios/flutter_inappwebview_ios/Sources/flutter_inappwebview_ios/InAppWebView/InAppWebView.swift
+++ b/flutter_inappwebview_ios/ios/flutter_inappwebview_ios/Sources/flutter_inappwebview_ios/InAppWebView/InAppWebView.swift
@@ -605,6 +605,10 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         if let applePayAPIEnabled = settings?.applePayAPIEnabled, applePayAPIEnabled {
             return
         }
+
+        let callAsyncJavaScriptResultHandlerName = CallAsyncJavaScriptBelowIOS14WrapperJS.RESULT_MESSAGE_HANDLER_NAME
+        configuration.userContentController.removeScriptMessageHandler(forName: callAsyncJavaScriptResultHandlerName)
+        configuration.userContentController.add(self, name: callAsyncJavaScriptResultHandlerName)
         
         if javaScriptBridgeEnabled {
             let pluginScriptsOriginAllowList = settings?.pluginScriptsOriginAllowList
@@ -1623,6 +1627,7 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
     public func callAsyncJavaScript(functionBody: String, arguments: [String:Any], completionHandler: ((Any?) -> Void)? = nil) {
         if let applePayAPIEnabled = settings?.applePayAPIEnabled, applePayAPIEnabled {
             completionHandler?(nil)
+            return
         }
         
         var jsToInject = functionBody
@@ -1649,6 +1654,8 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
             .replacingOccurrences(of: PluginScriptsUtil.VAR_FUNCTION_ARGUMENTS_OBJ, with: Util.JSONStringify(value: arguments))
             .replacingOccurrences(of: PluginScriptsUtil.VAR_FUNCTION_BODY, with: jsToInject)
             .replacingOccurrences(of: PluginScriptsUtil.VAR_RESULT_UUID, with: resultUuid)
+            .replacingOccurrences(of: CallAsyncJavaScriptBelowIOS14WrapperJS.VAR_WINDOW_ID,
+                                  with: windowId != nil ? String(windowId!) : "null")
         
         evaluateJavaScript(jsToInject) { (value, error) in
             if let error = error {
@@ -1657,7 +1664,10 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                                    userInfo["NSLocalizedDescription"] as? String ??
                                    error.localizedDescription
                 self.channelDelegate?.onConsoleMessage(message: String(describing: errorMessage), messageLevel: 3)
-                completionHandler?(nil)
+                completionHandler?([
+                    "value": NSNull(),
+                    "error": errorMessage
+                ])
                 self.callAsyncJavaScriptBelowIOS14Results.removeValue(forKey: resultUuid)
             }
         }
@@ -2945,6 +2955,30 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
 //    }
     
     public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        if message.name == CallAsyncJavaScriptBelowIOS14WrapperJS.RESULT_MESSAGE_HANDLER_NAME {
+            guard let messageBody = message.body as? String,
+                  let data = messageBody.data(using: .utf8),
+                  let jsonData = try? JSONSerialization.jsonObject(with: data, options: .mutableContainers) as? [String: Any],
+                  let resultUuid = jsonData["resultUuid"] as? String else {
+                return
+            }
+
+            var targetWebView = message.webView as? InAppWebView ?? self
+            if let windowId = jsonData["windowId"] as? Int64,
+               let webViewTransport = plugin?.inAppWebViewManager?.windowWebViews[windowId] {
+                targetWebView = webViewTransport.webView
+            }
+
+            if let result = targetWebView.callAsyncJavaScriptBelowIOS14Results.removeValue(forKey: resultUuid) {
+                let body: [String: Any?] = [
+                    "value": jsonData["value"],
+                    "error": jsonData["error"]
+                ]
+                result(body)
+            }
+            return
+        }
+
         guard javaScriptBridgeEnabled else {
             return
         }
@@ -3554,6 +3588,9 @@ if(window.\(JavaScriptBridgeJS.get_JAVASCRIPT_BRIDGE_NAME())[\(_callHandlerID)] 
         webMessageListeners.removeAll()
         interceptOnlyAsyncAjaxRequestsPluginScript = nil
         if windowId == nil {
+            configuration.userContentController.removeScriptMessageHandler(
+                forName: CallAsyncJavaScriptBelowIOS14WrapperJS.RESULT_MESSAGE_HANDLER_NAME
+            )
             configuration.userContentController.removeAllPluginScriptMessageHandlers()
             configuration.userContentController.removeAllUserScripts()
             if #available(iOS 11.0, *) {

--- a/flutter_inappwebview_ios/ios/flutter_inappwebview_ios/Sources/flutter_inappwebview_ios/InAppWebView/WebViewChannelDelegate.swift
+++ b/flutter_inappwebview_ios/ios/flutter_inappwebview_ios/Sources/flutter_inappwebview_ios/InAppWebView/WebViewChannelDelegate.swift
@@ -432,19 +432,62 @@ public class WebViewChannelDelegate: ChannelDelegate {
             break
         case .callAsyncJavaScript:
             if let webView = webView, #available(iOS 10.3, *) {
-                if #available(iOS 14.3, *) { // on iOS 14.0, for some reason, it crashes
-                    let functionBody = arguments!["functionBody"] as! String
-                    let functionArguments = arguments!["arguments"] as! [String:Any]
+                let functionBody = arguments!["functionBody"] as! String
+                let functionArguments = arguments!["arguments"] as! [String:Any]
+                let contentWorldMap = arguments!["contentWorld"] as? [String:Any?]
+                let contentWorldName = contentWorldMap?["name"] as? String ?? "page"
+
+                if #available(iOS 18.0, *) {
                     var contentWorld = WKContentWorld.page
-                    if let contentWorldMap = arguments!["contentWorld"] as? [String:Any?] {
+                    if let contentWorldMap = contentWorldMap {
+                        contentWorld = WKContentWorld.fromMap(map: contentWorldMap, windowId: webView.windowId)!
+                    }
+                    webView.callAsyncJavaScript(functionBody: functionBody, arguments: functionArguments, contentWorld: contentWorld) { (value) in
+                        result(value)
+                    }
+                } else if #available(iOS 14.3, *), webView.windowId != nil {
+                    // Popup documents do not expose window.webkit, so the legacy result
+                    // handler cannot be used. Keep the PR #2776 behavior by forcing the
+                    // page world before custom-world bootstrap/cache generation.
+                    webView.callAsyncJavaScript(functionBody: functionBody, arguments: functionArguments, contentWorld: WKContentWorld.page) { (value) in
+                        result(value)
+                    }
+                } else if contentWorldName == "page" {
+                    // On iOS 14-17, the native content-world overload can
+                    // dereference a null pointer even when a nil frame correctly targets
+                    // the main frame. Use the existing Promise/evaluateJavaScript shim for
+                    // page-world calls in regular WebViews.
+                    webView.callAsyncJavaScript(functionBody: functionBody, arguments: functionArguments) { (value) in
+                        result(value)
+                    }
+                } else if #available(iOS 16.1, *) {
+                    // Preserve native isolation for custom worlds in regular WebViews.
+                    var contentWorld = WKContentWorld.page
+                    if let contentWorldMap = contentWorldMap {
+                        contentWorld = WKContentWorld.fromMap(map: contentWorldMap, windowId: webView.windowId)!
+                    }
+                    webView.callAsyncJavaScript(functionBody: functionBody, arguments: functionArguments, contentWorld: contentWorld) { (value) in
+                        result(value)
+                    }
+                } else if #available(iOS 16.0, *) {
+                    // The native overload can crash or never call its completion handler
+                    // on iOS 16.0.x. The legacy shim only supports the page world, so fail
+                    // explicitly instead of silently breaking custom-world isolation.
+                    result([
+                        "value": NSNull(),
+                        "error": "Custom content worlds are not supported by callAsyncJavaScript on iOS 16.0.x"
+                    ])
+                } else if #available(iOS 14.3, *) {
+                    // Preserve native isolation for custom worlds in regular WebViews.
+                    var contentWorld = WKContentWorld.page
+                    if let contentWorldMap = contentWorldMap {
                         contentWorld = WKContentWorld.fromMap(map: contentWorldMap, windowId: webView.windowId)!
                     }
                     webView.callAsyncJavaScript(functionBody: functionBody, arguments: functionArguments, contentWorld: contentWorld) { (value) in
                         result(value)
                     }
                 } else {
-                    let functionBody = arguments!["functionBody"] as! String
-                    let functionArguments = arguments!["arguments"] as! [String:Any]
+                    // The native async API crashes on iOS 14.0-14.2.
                     webView.callAsyncJavaScript(functionBody: functionBody, arguments: functionArguments) { (value) in
                         result(value)
                     }

--- a/flutter_inappwebview_ios/ios/flutter_inappwebview_ios/Sources/flutter_inappwebview_ios/PluginScriptsJS/CallAsyncJavaScriptBelowIOS14WrapperJS.swift
+++ b/flutter_inappwebview_ios/ios/flutter_inappwebview_ios/Sources/flutter_inappwebview_ios/PluginScriptsJS/CallAsyncJavaScriptBelowIOS14WrapperJS.swift
@@ -8,24 +8,42 @@
 import Foundation
 
 public class CallAsyncJavaScriptBelowIOS14WrapperJS {
+
+    public static let RESULT_MESSAGE_HANDLER_NAME = "flutterInAppWebViewCallAsyncJavaScriptResult"
+    public static let VAR_WINDOW_ID = "$IN_APP_WEBVIEW_CALL_ASYNC_JAVASCRIPT_WINDOW_ID"
     
     public static func CALL_ASYNC_JAVASCRIPT_BELOW_IOS_14_WRAPPER_JS() -> String {
         return """
         (function(obj) {
-            (async function(\(PluginScriptsUtil.VAR_FUNCTION_ARGUMENT_NAMES) {
+            var messageHandler = window.webkit.messageHandlers['\(RESULT_MESSAGE_HANDLER_NAME)'];
+            var jsonStringify = window.JSON.stringify;
+            var resultUuid = '\(PluginScriptsUtil.VAR_RESULT_UUID)';
+            var windowId = \(VAR_WINDOW_ID);
+            var sendResult = function(value, error) {
+                var message;
+                try {
+                    message = jsonStringify({
+                        'value': value === undefined ? null : value,
+                        'error': error,
+                        'resultUuid': resultUuid,
+                        'windowId': windowId
+                    });
+                } catch (serializationError) {
+                    message = jsonStringify({
+                        'value': null,
+                        'error': serializationError + '',
+                        'resultUuid': resultUuid,
+                        'windowId': windowId
+                    });
+                }
+                messageHandler.postMessage(message);
+            };
+            (async function(\(PluginScriptsUtil.VAR_FUNCTION_ARGUMENT_NAMES)) {
                 \(PluginScriptsUtil.VAR_FUNCTION_BODY)
             })(\(PluginScriptsUtil.VAR_FUNCTION_ARGUMENT_VALUES)).then(function(value) {
-                window.\(JavaScriptBridgeJS.get_JAVASCRIPT_BRIDGE_NAME()).callHandler('onCallAsyncJavaScriptResultBelowIOS14Received', {
-                    'value': value, 
-                    'error': null,
-                    'resultUuid': '\(PluginScriptsUtil.VAR_RESULT_UUID)'
-                });
+                sendResult(value, null);
             }).catch(function(error) {
-                window.\(JavaScriptBridgeJS.get_JAVASCRIPT_BRIDGE_NAME()).callHandler('onCallAsyncJavaScriptResultBelowIOS14Received', {
-                    'value': null, 
-                    'error': error + '',
-                    'resultUuid': '\(PluginScriptsUtil.VAR_RESULT_UUID)'
-                });
+                sendResult(null, error + '');
             });
             return null;
         })(\(PluginScriptsUtil.VAR_FUNCTION_ARGUMENTS_OBJ));


### PR DESCRIPTION
## Summary

`callAsyncJavaScript` has unsafe or broken compatibility paths on older iOS versions. In particular, the fallback wrapper generates an invalid async-function signature when arguments are inserted (#2668), while the native content-world overload can crash or fail to complete on affected iOS 14–17 combinations.

This change:

- fixes the fallback wrapper's async-function signature;
- routes regular page-world calls through the Promise/`evaluateJavaScript` compatibility path before iOS 18;
- delivers fallback results through a dedicated `WKScriptMessageHandler`, including when `javaScriptBridgeEnabled` is `false`;
- preserves native custom-world isolation where that path is stable and returns an explicit error for custom worlds on iOS 16.0.x;
- forces popup (`windowId`) async calls to the page world on iOS 14.3–17, complementing #2776;
- returns structured JavaScript and serialization errors instead of losing the completion callback;
- adds regression coverage for resolved/rejected Promises, bridge-disabled WebViews, and custom-content-world behavior.

## Connection with issue(s)

Resolves #2668.

Related to #2776. This PR handles the `callAsyncJavaScript` path; the popup `evaluateJavaScript` fix remains scoped to #2776.

## Testing and Review Notes

Checks performed locally:

- [x] Dart formatting check for the updated integration test (0 files changed)
- [x] Swift parser check for the three changed Swift files
- [x] CRLF-aware whitespace check
- [ ] iOS integration suite on simulators/devices

The updated integration coverage includes Promise resolution with arguments, Promise rejection surfaced through `CallAsyncJavaScriptResult.error`, operation with `javaScriptBridgeEnabled: false`, custom-world isolation on supported versions, and the explicit iOS 16.0.x custom-world error.

Recommended device matrix: iOS 12/13, 14.0–14.2, 14.3, 15.x, 16.0.x, 16.1+, 17.x, and 18+.

### Known limitations and review points

- Custom content worlds fall back to page-world semantics on iOS 12–14.2.
- Custom content worlds return an explicit unsupported error on iOS 16.0.x.
- Popup async calls use the page world on iOS 14.3–17, so custom-world isolation is not preserved there.
- The compatibility path normalizes `undefined` to `null` and requires JSON-serializable results.
- The dedicated internal message handler remains registered when the public JavaScript bridge is disabled; it only resolves pending calls by UUID and should receive security review.
- iOS 18+ continues to use the native API with the requested content world and still needs device validation.
- This change is iOS-only; macOS behavior is unchanged.

## Screenshots or Videos

Not applicable; this is a non-visual runtime fix.

## To Do

- [ ] Run the iOS integration suite on representative affected versions
- [x] Add regression coverage and review notes
- [x] UX review is not applicable
