### PR TITLE
fix(windows): prevent crash on unknown WebView2 permission resources

### DIFF
--- a/flutter_inappwebview_platform_interface/lib/src/types/permission_request.g.dart
+++ b/flutter_inappwebview_platform_interface/lib/src/types/permission_request.g.dart
@@ -19,55 +19,31 @@ class PermissionRequest {
   ///**NOTE for iOS, macOS and Windows**: this list will have only 1 element and will be used by the [PermissionResponse.action]
   ///as the resource to consider when applying the corresponding action.
   List<PermissionResourceType> resources;
-  PermissionRequest({
-    this.frame,
-    required this.origin,
-    this.resources = const [],
-  });
+  PermissionRequest(
+      {this.frame, required this.origin, this.resources = const []});
 
   ///Gets a possible [PermissionRequest] instance from a [Map] value.
-  static PermissionRequest? fromMap(
-    Map<String, dynamic>? map, {
-    EnumMethod? enumMethod,
-  }) {
+  static PermissionRequest? fromMap(Map<String, dynamic>? map) {
     if (map == null) {
       return null;
     }
     final instance = PermissionRequest(
-      frame: FrameInfo.fromMap(
-        map['frame']?.cast<String, dynamic>(),
-        enumMethod: enumMethod,
-      ),
+      frame: FrameInfo.fromMap(map['frame']?.cast<String, dynamic>()),
       origin: WebUri(map['origin']),
     );
-    if (map['resources'] != null) {
-      instance.resources = List<PermissionResourceType>.from(
-        map['resources'].map(
-          (e) => switch (enumMethod ?? EnumMethod.nativeValue) {
-            EnumMethod.nativeValue => PermissionResourceType.fromNativeValue(e),
-            EnumMethod.value => PermissionResourceType.fromValue(e),
-            EnumMethod.name => PermissionResourceType.byName(e),
-          }!,
-        ),
-      );
-    }
+    instance.resources = List<PermissionResourceType>.from(map['resources']
+        .map((e) => PermissionResourceType.fromNativeValue(e))
+        .where((e) => e != null)
+        .cast<PermissionResourceType>());
     return instance;
   }
 
   ///Converts instance to a map.
-  Map<String, dynamic> toMap({EnumMethod? enumMethod}) {
+  Map<String, dynamic> toMap() {
     return {
-      "frame": frame?.toMap(enumMethod: enumMethod),
+      "frame": frame?.toMap(),
       "origin": origin.toString(),
-      "resources": resources
-          .map(
-            (e) => switch (enumMethod ?? EnumMethod.nativeValue) {
-              EnumMethod.nativeValue => e.toNativeValue(),
-              EnumMethod.value => e.toValue(),
-              EnumMethod.name => e.name(),
-            },
-          )
-          .toList(),
+      "resources": resources.map((e) => e.toNativeValue()).toList(),
     };
   }
 

--- a/flutter_inappwebview_platform_interface/lib/src/types/permission_response.g.dart
+++ b/flutter_inappwebview_platform_interface/lib/src/types/permission_response.g.dart
@@ -15,58 +15,28 @@ class PermissionResponse {
   ///
   ///**NOTE for iOS, macOS and Windows**: not used. The [action] taken is based on the [PermissionRequest.resources].
   List<PermissionResourceType> resources;
-  PermissionResponse({
-    PermissionResponseAction? action,
-    this.resources = const [],
-  }) : action = action ?? PermissionResponseAction.DENY;
+  PermissionResponse(
+      {this.action = PermissionResponseAction.DENY, this.resources = const []});
 
   ///Gets a possible [PermissionResponse] instance from a [Map] value.
-  static PermissionResponse? fromMap(
-    Map<String, dynamic>? map, {
-    EnumMethod? enumMethod,
-  }) {
+  static PermissionResponse? fromMap(Map<String, dynamic>? map) {
     if (map == null) {
       return null;
     }
     final instance = PermissionResponse();
-    instance.action = switch (enumMethod ?? EnumMethod.nativeValue) {
-      EnumMethod.nativeValue => PermissionResponseAction.fromNativeValue(
-        map['action'],
-      ),
-      EnumMethod.value => PermissionResponseAction.fromValue(map['action']),
-      EnumMethod.name => PermissionResponseAction.byName(map['action']),
-    };
-    if (map['resources'] != null) {
-      instance.resources = List<PermissionResourceType>.from(
-        map['resources'].map(
-          (e) => switch (enumMethod ?? EnumMethod.nativeValue) {
-            EnumMethod.nativeValue => PermissionResourceType.fromNativeValue(e),
-            EnumMethod.value => PermissionResourceType.fromValue(e),
-            EnumMethod.name => PermissionResourceType.byName(e),
-          }!,
-        ),
-      );
-    }
+    instance.action = PermissionResponseAction.fromNativeValue(map['action']);
+    instance.resources = List<PermissionResourceType>.from(map['resources']
+        .map((e) => PermissionResourceType.fromNativeValue(e))
+        .where((e) => e != null)
+        .cast<PermissionResourceType>());
     return instance;
   }
 
   ///Converts instance to a map.
-  Map<String, dynamic> toMap({EnumMethod? enumMethod}) {
+  Map<String, dynamic> toMap() {
     return {
-      "action": switch (enumMethod ?? EnumMethod.nativeValue) {
-        EnumMethod.nativeValue => action?.toNativeValue(),
-        EnumMethod.value => action?.toValue(),
-        EnumMethod.name => action?.name(),
-      },
-      "resources": resources
-          .map(
-            (e) => switch (enumMethod ?? EnumMethod.nativeValue) {
-              EnumMethod.nativeValue => e.toNativeValue(),
-              EnumMethod.value => e.toValue(),
-              EnumMethod.name => e.name(),
-            },
-          )
-          .toList(),
+      "action": action?.toNativeValue(),
+      "resources": resources.map((e) => e.toNativeValue()).toList(),
     };
   }
 
@@ -90,43 +60,26 @@ class PermissionRequestResponse {
 
   ///Resources granted to be accessed by origin.
   List<String> resources;
-  PermissionRequestResponse({
-    PermissionRequestResponseAction? action,
-    this.resources = const [],
-  }) : action = action ?? PermissionRequestResponseAction.DENY;
+  PermissionRequestResponse(
+      {this.action = PermissionRequestResponseAction.DENY,
+      this.resources = const []});
 
   ///Gets a possible [PermissionRequestResponse] instance from a [Map] value.
-  static PermissionRequestResponse? fromMap(
-    Map<String, dynamic>? map, {
-    EnumMethod? enumMethod,
-  }) {
+  static PermissionRequestResponse? fromMap(Map<String, dynamic>? map) {
     if (map == null) {
       return null;
     }
     final instance = PermissionRequestResponse();
-    instance.action = switch (enumMethod ?? EnumMethod.nativeValue) {
-      EnumMethod.nativeValue => PermissionRequestResponseAction.fromNativeValue(
-        map['action'],
-      ),
-      EnumMethod.value => PermissionRequestResponseAction.fromValue(
-        map['action'],
-      ),
-      EnumMethod.name => PermissionRequestResponseAction.byName(map['action']),
-    };
-    if (map['resources'] != null) {
-      instance.resources = List<String>.from(map['resources']!.cast<String>());
-    }
+    instance.action =
+        PermissionRequestResponseAction.fromNativeValue(map['action']);
+    instance.resources = List<String>.from(map['resources']!.cast<String>());
     return instance;
   }
 
   ///Converts instance to a map.
-  Map<String, dynamic> toMap({EnumMethod? enumMethod}) {
+  Map<String, dynamic> toMap() {
     return {
-      "action": switch (enumMethod ?? EnumMethod.nativeValue) {
-        EnumMethod.nativeValue => action?.toNativeValue(),
-        EnumMethod.value => action?.toValue(),
-        EnumMethod.name => action?.name(),
-      },
+      "action": action?.toNativeValue(),
       "resources": resources,
     };
   }


### PR DESCRIPTION
## Summary

This PR prevents a crash on Windows when WebView2 returns an unknown permission resource ID.

Previously, `PermissionRequest.fromMap` force-unwrapped the result of `PermissionResourceType.fromNativeValue(...)`, which caused a runtime exception when the permission resource was not recognized.

This change safely ignores unsupported permission resource IDs instead of crashing.

## Changes

- Handle unknown permission resource IDs gracefully.
- Filter out unsupported permission resources instead of force-unwrapping them.
- Preserve existing behavior for all supported permission resources.

## Testing

Tested on Windows using `https://web.whatsapp.com/`.

The application no longer crashes when the website requests an unsupported permission resource.

Fixes #2875